### PR TITLE
Feature: Complete the connect msg path with timeout

### DIFF
--- a/jclklib/client/client_state.cpp
+++ b/jclklib/client/client_state.cpp
@@ -1,10 +1,16 @@
 #include <client/client_state.hpp>
+#include <common/jcltypes.hpp>
 
 using namespace JClkLibClient;
 
 ClientState::ClientState()
 {
 	connected = false;
+	sessionId = JClkLibCommon::InvalidSessionId;
 }
+
+bool ClientState::get_connected() {return connected;}
+
+void ClientState::set_connected(bool new_state) {connected = new_state;}
 
 ClientState JClkLibClient::state{};

--- a/jclklib/client/client_state.hpp
+++ b/jclklib/client/client_state.hpp
@@ -3,15 +3,17 @@
 
 #include <common/jcltypes.hpp>
 #include <common/util.hpp>
+#include <atomic>
 
 namespace JClkLibClient {
 	class ClientState {
 	private:
-		bool connected;
+		std::atomic_bool connected;
 		JClkLibCommon::sessionId_t sessionId;
 	public:
 		ClientState();
-		DECLARE_ACCESSOR(connected);
+		bool get_connected();
+		void set_connected(bool state);
 		DECLARE_ACCESSOR(sessionId);
 	};
 

--- a/jclklib/client/connect_msg.cpp
+++ b/jclklib/client/connect_msg.cpp
@@ -68,5 +68,8 @@ PROCESS_MESSAGE_TYPE(ClientConnectMessage::processMessage)
         /*[TODO] client runtime shd return client ID to application - return client ID at least */
         /*[Question] ACK_NONE is necessary ?*/
 	this->set_msgAck(ACK_NONE);
+
+        cv.notify_one();
+
         return true;
 }

--- a/jclklib/client/connect_msg.hpp
+++ b/jclklib/client/connect_msg.hpp
@@ -10,6 +10,8 @@
 
 #include <common/connect_msg.hpp>
 #include <client/message.hpp>
+#include <mutex>
+#include <condition_variable>
 
 namespace JClkLibClient
 {
@@ -17,7 +19,12 @@ namespace JClkLibClient
 				     virtual public ClientMessage
 	{
 	public:
+
 		ClientConnectMessage() : MESSAGE_CONNECT() {};
+
+		static std::mutex cv_mtx;
+		static std::condition_variable cv;
+
 		/**
 		 * @brief process the reply for connect msg from proxy.
 		 * @param LxContext client run-time transport listener context

--- a/jclklib/client/test.cpp
+++ b/jclklib/client/test.cpp
@@ -8,14 +8,38 @@
 #include "init.hpp"
 
 #include <unistd.h>
+#include <iostream>
+#include <stdlib.h>
+#include <common/jclklib_import.hpp>
+#include <client/client_state.hpp>
+#include <client/connect_msg.hpp>
 
 using namespace JClkLibClient;
+using namespace JClkLibCommon;
 using namespace std;
 
 int main()
 {
-	connect();
-	sleep(1);
+    int ret = EXIT_SUCCESS;
+    // TODO
+    // JClkLibCommon::jcl_subscription sub;
+
+    std::cout << "[CLIENT] Before connect : Session ID : " << state.get_sessionId() << "\n";
+
+    if (connect() == false) {
+        std::cout << "[CLIENT] Failure in connecting !!!\n";
+        ret = EXIT_FAILURE;
+        goto do_exit;
+    }
+    else {
+        std::cout << "[CLIENT] Connected. Session ID : " << state.get_sessionId() << "\n";
+    }
+    sleep(5);
+    // TODO
+    // subscribe(sub);
+	sleep(5);
  do_exit:
 	disconnect();
+
+    return ret;
 }

--- a/jclklib/common/connect_msg.cpp
+++ b/jclklib/common/connect_msg.cpp
@@ -26,6 +26,9 @@ PARSE_RXBUFFER_TYPE(CommonConnectMessage::parseBuffer) {
 	if(!Message::parseBuffer(LxContext))
 		return false;
 
+	if (!PARSE_RX(FIELD, get_sessionId(), LxContext))
+		return false;
+
 	if (!PARSE_RX(ARRAY,clientId, LxContext))
 		return false;
 
@@ -38,6 +41,9 @@ BUILD_TXBUFFER_TYPE(CommonConnectMessage::makeBuffer) const
 	auto ret = Message::makeBuffer(TxContext); 
 	if (!ret)
 		return ret;
+
+	if (!WRITE_TX(FIELD, c_get_val_sessionId(), TxContext))
+		return false;
 
 	if (!WRITE_TX(ARRAY,clientId,TxContext))
 		return false;

--- a/jclklib/common/util.hpp
+++ b/jclklib/common/util.hpp
@@ -26,7 +26,8 @@ bool isFutureSet(std::future<type> &f)
 #define DECLARE_ACCESSOR(varname)					\
 	const decltype(varname) &getc_##varname() { return varname; }		\
 	decltype(varname) &get_##varname() { return varname; }		\
-	void set_##varname (const decltype(varname) &varname) { this->varname = varname; }
+	void set_##varname (const decltype(varname) &varname) { this->varname = varname; }		\
+	decltype(varname) c_get_val_##varname () const { return varname; }
 
 #define PTHREAD_CALL(func,err_msg,retval)				\
 	{								\


### PR DESCRIPTION
The connect message now will return the client session ID to the client. It will also have the timeout of 5 sec by default to receive the proxy reply.

This could be changed in the future.