### PR TITLE
Connect: Send ptp4l_id from Proxy to Client once ptp4l is connected

### DIFF
--- a/jclklib/client/connect_msg.cpp
+++ b/jclklib/client/connect_msg.cpp
@@ -7,6 +7,8 @@
 
 #include <client/connect_msg.hpp>
 #include <common/print.hpp>
+#include <common/serialize.hpp>
+#include <common/jclklib_import.hpp>
 
 using namespace JClkLibClient;
 using namespace JClkLibCommon;
@@ -36,6 +38,21 @@ bool ClientConnectMessage::initMessage()
 {
         addMessageType(parseMsgMapElement_t(CONNECT_MSG, buildMessage));
         return true;
+}
+
+PARSE_RXBUFFER_TYPE(ClientConnectMessage::parseBuffer) {
+	JClkLibCommon::ptp_event data;
+
+	PrintDebug("[ClientConnectMessage]::parseBuffer ");
+	if(!CommonConnectMessage::parseBuffer(LxContext))
+		return false;
+
+	if (!PARSE_RX(FIELD, data.ptp4l_id, LxContext))
+		return false;
+
+	printf("ptp4l_id = %d\n\n", data.ptp4l_id);
+
+	return true;
 }
 
 /** @brief process the reply for connect msg from proxy.

--- a/jclklib/client/connect_msg.hpp
+++ b/jclklib/client/connect_msg.hpp
@@ -32,6 +32,7 @@ namespace JClkLibClient
 		 * @return true
 		 */
 		virtual PROCESS_MESSAGE_TYPE(processMessage);
+		virtual PARSE_RXBUFFER_TYPE(parseBuffer);
 
 		/**
 		 * @brief Create the ClientConnectMessage object

--- a/jclklib/client/subscribe_msg.cpp
+++ b/jclklib/client/subscribe_msg.cpp
@@ -56,7 +56,7 @@ PARSE_RXBUFFER_TYPE(ClientSubscribeMessage::parseBuffer) {
 		data.gmIdentity[0], data.gmIdentity[1],data.gmIdentity[2],
 		data.gmIdentity[3], data.gmIdentity[4],
 		data.gmIdentity[5], data.gmIdentity[6],data.gmIdentity[7]);
-	printf("asCapable = %d\n\n", data.asCapable);
+	printf("asCapable = %d, ptp4l_id = %d\n\n", data.asCapable, data.ptp4l_id);
 
 	return true;
 }

--- a/jclklib/common/jclklib_import.hpp
+++ b/jclklib/common/jclklib_import.hpp
@@ -103,6 +103,7 @@ namespace JClkLibCommon
 		uint8_t gmIdentity[8]; /* Grandmaster clock ID */
 		int32_t asCapable; /* 802@.1AS Capable */
 		uint8_t servo_state;
+		uint8_t ptp4l_id;
 	};
 }
 

--- a/jclklib/proxy/connect.cpp
+++ b/jclklib/proxy/connect.cpp
@@ -36,7 +36,6 @@ static std::unique_ptr<SockBase> m_sk;
 
 struct port_info {
     PortIdentity_t portid;
-    std::string interface;
     int64_t master_offset;
     bool local;
 };
@@ -44,7 +43,7 @@ struct port_info {
 int epd;
 struct epoll_event epd_event;
 SUBSCRIBE_EVENTS_NP_t d;
-JClkLibCommon::ptp_event pe;
+JClkLibCommon::ptp_event pe = { 0, {0, 0, 0, 0, 0, 0, 0, 0}, 0 , 0 , 0};
 
 void event_handle()
 {
@@ -216,17 +215,20 @@ int Connect::connect()
     MsgParams prms = msg.getParams();
     prms.boundaryHops = 0;
 
-    std::string interface;
     std::unique_ptr<SockBase> m_sk;
     std::string uds_address;
 
-    //TODO: hard-coded the interface
-    interface = "enp1s0";
     SockUnix *sku = new SockUnix;
     if(sku == nullptr) {
         return -1;
     }
     m_sk.reset(sku);
+
+    while (system("ls /var/run/ptp4l*") != 0) {
+        //sleep for 2 seconds and keep looping until there is ptp4l available
+        sleep(2);
+    }
+    pe.ptp4l_id = 1;
 
     //TODO: hard-coded uds_socket
     uds_address = "/var/run/ptp4l";

--- a/jclklib/proxy/connect_msg.hpp
+++ b/jclklib/proxy/connect_msg.hpp
@@ -25,6 +25,7 @@ namespace JClkLibProxy
 		 * @return true
 		 */
 		virtual PROCESS_MESSAGE_TYPE(processMessage);
+		virtual BUILD_TXBUFFER_TYPE(makeBuffer) const;
 
 		bool generateResponse(uint8_t *msgBuffer, std::size_t &length,
 				      const ClockStatus &status)

--- a/jclklib/proxy/thread.cpp
+++ b/jclklib/proxy/thread.cpp
@@ -182,7 +182,8 @@ int connect_ptp4l( struct ptp4l_handle **phandle, struct epoll_event epd_event, 
 {
 	struct ptp4l_handle *handle;
 	int ret;
-	char *path;
+	//TODO: hard-coded for now
+	char path[] = "/var/run/ptp4l";
 
 	handle = (typeof( handle)) malloc(( size_t) sizeof(*handle));
 	if( handle == NULL) {
@@ -193,8 +194,6 @@ int connect_ptp4l( struct ptp4l_handle **phandle, struct epoll_event epd_event, 
 	memset( &handle->server_addr, 0, sizeof( handle->server_addr));
 	handle->server_addr.sun_family = AF_LOCAL;
 
-	//TODO: hard-coded for now
-	path = "/var/run/ptp4l";
 	strncpy( handle->server_addr.sun_path, path,
 		 sizeof( handle->server_addr.sun_path ) - 1);
 


### PR DESCRIPTION
1. Client is receiving ptp4l_id once proxy is connected to ptp4l
![image](https://github.com/intel-staging/libptpmgmt_iaclocklib/assets/49394711/ac48b603-eb24-407d-92ae-bd36428341b1)

2. Client will getting connection failed if proxy is not connected to ptp4l
![image](https://github.com/intel-staging/libptpmgmt_iaclocklib/assets/49394711/acc1c95a-c5f1-450f-83a1-fc6ba9fd9aad)
