### PR TITLE
jclklib: Add composite event support

### DIFF
--- a/jclklib/client/init.cpp
+++ b/jclklib/client/init.cpp
@@ -102,6 +102,7 @@ bool JClkLibClient::jcl_subscribe(JClkLibCommon::jcl_subscription &newSub,
 	/* Write the current event subscription */
 	state.get_eventSub().set_event(newSub.getc_event());
 	state.get_eventSub().set_value(newSub.getc_value());
+	state.get_eventSub().set_composite_event(newSub.getc_composite_event());
 
 	cmsg->getSubscription().get_event().copyEventMask(newSub.get_event());
 
@@ -191,6 +192,7 @@ int JClkLibClient::jcl_status_wait(int timeout, JClkLibCommon::jcl_state &jcl_st
 		    eventCount.asCapable_event_count ||
 		    eventCount.servo_locked_event_count ||
 		    eventCount.gmPresent_event_count ||
+		    eventCount.composite_event_count ||
 		    eventCount.gm_changed_event_count) {
 			event_changes_detected = true;
 			break;
@@ -213,6 +215,8 @@ int JClkLibClient::jcl_status_wait(int timeout, JClkLibCommon::jcl_state &jcl_st
 	client_ptp_data.gmPresent_event_count.fetch_sub(eventCount.gmPresent_event_count,
 							std::memory_order_relaxed);
 	client_ptp_data.gmChanged_event_count.fetch_sub(eventCount.gm_changed_event_count,
+							std::memory_order_relaxed);
+	client_ptp_data.composite_event_count.fetch_sub(eventCount.composite_event_count,
 							std::memory_order_relaxed);
 
 	return true;

--- a/jclklib/client/notification_msg.cpp
+++ b/jclklib/client/notification_msg.cpp
@@ -22,6 +22,7 @@ using namespace JClkLibCommon;
 using namespace JClkLibClient;
 
 JClkLibCommon::client_ptp_event client_ptp_data;
+JClkLibCommon::client_ptp_event composite_client_ptp_data;
 JClkLibCommon::ptp_event proxy_data = {};
 JClkLibCommon::jcl_state jclCurrentState = {};
 JClkLibCommon::jcl_state_event_count jclCurrentEventCount = {};
@@ -64,6 +65,9 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
 
 	std::uint32_t eventSub[1];
 	state.get_eventSub().get_event().readEvent(eventSub, (std::size_t)sizeof(eventSub));
+	std::uint32_t composite_eventSub[1];
+	state.get_eventSub().get_composite_event().readEvent(composite_eventSub, (std::size_t)sizeof(composite_eventSub));
+	bool old_composite_event;
 
 	if ((eventSub[0] & 1<<gmOffsetEvent) && (proxy_data.master_offset != client_ptp_data.master_offset)) {
 		client_ptp_data.master_offset = proxy_data.master_offset;
@@ -109,10 +113,39 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
 		client_ptp_data.gmPresent_event_count.fetch_add(1, std::memory_order_relaxed);
 	}
 
+	if (composite_eventSub[0]) {
+		old_composite_event = composite_client_ptp_data.composite_event;
+		composite_client_ptp_data.composite_event = true;
+	}
+
+	if ((composite_eventSub[0] & 1<<gmOffsetEvent) && (proxy_data.master_offset != composite_client_ptp_data.master_offset)) {
+		composite_client_ptp_data.master_offset = proxy_data.master_offset;
+		if ((composite_client_ptp_data.master_offset > state.get_eventSub().get_value().getLower(gmOffsetValue)) &&
+		    (composite_client_ptp_data.master_offset < state.get_eventSub().get_value().getUpper(gmOffsetValue))) {
+			composite_client_ptp_data.composite_event = true;
+		}
+		else {
+			composite_client_ptp_data.composite_event = false;
+		}
+	}
+
+	if ((composite_eventSub[0] & 1<<servoLockedEvent) && (proxy_data.servo_state != composite_client_ptp_data.servo_state)) {
+		composite_client_ptp_data.composite_event &= proxy_data.servo_state >= SERVO_LOCKED ? true:false;
+	}
+
+	if ((composite_eventSub[0] & 1<<asCapableEvent) && (proxy_data.asCapable != composite_client_ptp_data.asCapable)) {
+		composite_client_ptp_data.composite_event &= proxy_data.asCapable > 0 ? true:false;
+	}
+
+	if (composite_eventSub[0] && (old_composite_event != composite_client_ptp_data.composite_event)) {
+		client_ptp_data.composite_event_count.fetch_add(1, std::memory_order_relaxed);
+	}
+
 	jclCurrentState.gm_present = client_ptp_data.gmPresent > 0 ? true:false;
 	jclCurrentState.as_Capable = client_ptp_data.asCapable > 0 ? true:false;
 	jclCurrentState.offset_in_range = client_ptp_data.master_offset_within_boundary;
 	jclCurrentState.servo_locked = client_ptp_data.servo_state >= SERVO_LOCKED ? true:false;
+	jclCurrentState.composite_event = composite_client_ptp_data.composite_event;
 	memcpy(jclCurrentState.gmIdentity, client_ptp_data.gmIdentity, sizeof(client_ptp_data.gmIdentity));
 
 	/* TODO : checked for jclCurrentState.gm_changed based on GM_identity previously stored */
@@ -122,6 +155,7 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
 	jclCurrentEventCount.asCapable_event_count = client_ptp_data.asCapable_event_count;
 	jclCurrentEventCount.servo_locked_event_count = client_ptp_data.servo_state_event_count;
 	jclCurrentEventCount.gm_changed_event_count = client_ptp_data.gmChanged_event_count;
+	jclCurrentEventCount.composite_event_count = client_ptp_data.composite_event_count;
 
 	state.set_eventState (jclCurrentState);
 	state.set_eventStateCount (jclCurrentEventCount);

--- a/jclklib/client/subscribe_msg.cpp
+++ b/jclklib/client/subscribe_msg.cpp
@@ -21,6 +21,7 @@ using namespace JClkLibCommon;
 using namespace std;
 
 JClkLibCommon::client_ptp_event client_data = {};
+JClkLibCommon::client_ptp_event composite_client_data = {};
 
 /** @brief Create the ClientSubscribeMessage object
  *
@@ -56,6 +57,9 @@ PARSE_RXBUFFER_TYPE(ClientSubscribeMessage::parseBuffer) {
 
 	std::uint32_t eventSub[1];
 	state.get_eventSub().get_event().readEvent(eventSub, (std::size_t)sizeof(eventSub));
+
+	std::uint32_t composite_eventSub[1];
+	state.get_eventSub().get_composite_event().readEvent(composite_eventSub, (std::size_t)sizeof(composite_eventSub));
 
 	PrintDebug("[ClientSubscribeMessage]::parseBuffer ");
 	if(!CommonSubscribeMessage::parseBuffer(LxContext))
@@ -97,6 +101,28 @@ PARSE_RXBUFFER_TYPE(ClientSubscribeMessage::parseBuffer) {
 		client_data.gmPresent = data.gmPresent;
 	}
 
+	if (composite_eventSub[0]) {
+		composite_client_data.composite_event = true;
+	}
+
+	if ((composite_eventSub[0] & 1<<gmOffsetEvent) && (data.master_offset != composite_client_data.master_offset)) {
+		composite_client_data.master_offset = data.master_offset;
+		if ((composite_client_data.master_offset > state.get_eventSub().get_value().getLower(gmOffsetValue)) &&
+		    (composite_client_data.master_offset < state.get_eventSub().get_value().getUpper(gmOffsetValue))) {
+			composite_client_data.composite_event = true;
+		} else {
+			composite_client_data.composite_event = false;
+		}
+	}
+
+	if ((composite_eventSub[0] & 1<<servoLockedEvent) && (data.servo_state != composite_client_data.servo_state)) {
+		composite_client_data.composite_event &= data.servo_state >= SERVO_LOCKED ? true:false;
+	}
+
+	if ((composite_eventSub[0] & 1<<asCapableEvent) && (data.asCapable != composite_client_data.asCapable)) {
+		composite_client_data.composite_event &= data.asCapable > 0 ? true:false;
+	}
+
 	printf("CLIENT master_offset = %ld, servo_state = %d gmPresent = %d\n", client_data.master_offset, client_data.servo_state, client_data.gmPresent);
 	printf("gmIdentity = %02x%02x%02x.%02x%02x.%02x%02x%02x ",
 		client_data.gmIdentity[0], client_data.gmIdentity[1],client_data.gmIdentity[2],
@@ -108,6 +134,7 @@ PARSE_RXBUFFER_TYPE(ClientSubscribeMessage::parseBuffer) {
 	jclCurrentState.as_Capable = client_data.asCapable > 0 ? true:false;
 	jclCurrentState.offset_in_range = client_data.master_offset_within_boundary;
 	jclCurrentState.servo_locked = client_data.servo_state >= SERVO_LOCKED ? true:false;
+	jclCurrentState.composite_event = composite_client_data.composite_event;
 	memcpy(jclCurrentState.gmIdentity, client_data.gmIdentity, sizeof(client_data.gmIdentity));
 	/* TODO : checked for jclCurrentState.gm_changed based on GM_identity previously stored */
 

--- a/jclklib/client/test.cpp
+++ b/jclklib/client/test.cpp
@@ -42,7 +42,8 @@ int main()
     JClkLibCommon::jcl_state_event_count eventCount = {};
     int timeout = 10;
 
-    std::uint32_t event2Sub1[1] = {((1<<gmPresentEvent)|(1<<gmChangedEvent)|(1<<servoLockedEvent)|(1<<gmOffsetEvent))};
+    std::uint32_t event2Sub1[1] = {((1<<asCapableEvent)|(1<<gmPresentEvent)|(1<<gmChangedEvent)|(1<<servoLockedEvent)|(1<<gmOffsetEvent))};
+    std::uint32_t composite_event[1] = {((1<<asCapableEvent)|(1<<servoLockedEvent)|(1<<gmOffsetEvent))};
 
     signal(SIGINT, signal_handler);
     signal(SIGTERM, signal_handler);
@@ -62,6 +63,7 @@ int main()
 
     sub.get_event().writeEvent(event2Sub1, (std::size_t)sizeof(event2Sub1));
     sub.get_value().setValue(gmOffsetValue, 100000, -100000);
+    sub.get_composite_event().writeEvent(composite_event, (std::size_t)sizeof(composite_event));
     std::cout << "[CLIENT] set subscribe event : " + sub.c_get_val_event().toString() << "\n";
     jcl_subscribe(sub, currentState);
     std::cout << "[CLIENT] " + state.toString();
@@ -73,25 +75,37 @@ int main()
             continue;
         }
 
-        printf("+------------------+--------------+-------------+\n");
-        printf("| %-16s | %-12s | %-11s |\n", "Event", "Event Status", "Event Count");
-        printf("+------------------+--------------+-------------+\n");
-        printf("| %-16s | %-12d | %-11ld |\n", "offset_in_range",
+        printf("+-------------------+--------------+-------------+\n");
+        printf("| %-17s | %-12s | %-11s |\n", "Event", "Event Status", "Event Count");
+        printf("+-------------------+--------------+-------------+\n");
+        printf("| %-17s | %-12d | %-11ld |\n", "offset_in_range",
             jcl_state.offset_in_range, eventCount.offset_in_range_event_count);
-        printf("| %-16s | %-12d | %-11ld |\n", "servo_locked",
+        printf("| %-17s | %-12d | %-11ld |\n", "servo_locked",
             jcl_state.servo_locked, eventCount.servo_locked_event_count);
-        printf("| %-16s | %-12d | %-11ld |\n", "gmPresent",
-            jcl_state.gm_present, eventCount.gmPresent_event_count);
-        printf("| %-16s | %-12d | %-11ld |\n", "as_Capable",
+        printf("| %-17s | %-12d | %-11ld |\n", "as_Capable",
             jcl_state.as_Capable, eventCount.asCapable_event_count);
-        printf("| %-16s | %-12d | %-11ld |\n", "gm_Changed",
+        printf("| %-17s | %-12d | %-11ld |\n", "gmPresent",
+            jcl_state.gm_present, eventCount.gmPresent_event_count);
+        printf("| %-17s | %-12d | %-11ld |\n", "gm_Changed",
             jcl_state.gm_changed, eventCount.gm_changed_event_count);
-        printf("+------------------+--------------+-------------+\n");
-        printf("| %-16s |     %02x%02x%02x.%02x%02x.%02x%02x%02x     |\n", "UUID",
+        printf("+-------------------+--------------+-------------+\n");
+        printf("| %-17s |     %02x%02x%02x.%02x%02x.%02x%02x%02x     |\n", "UUID",
             jcl_state.gmIdentity[0], jcl_state.gmIdentity[1], jcl_state.gmIdentity[2],
             jcl_state.gmIdentity[3], jcl_state.gmIdentity[4],
             jcl_state.gmIdentity[5], jcl_state.gmIdentity[6], jcl_state.gmIdentity[7]);
-        printf("+------------------+----------------------------+\n\n");
+        printf("+-------------------+--------------+-------------+\n");
+        printf("| %-17s | %-12d | %-11ld |\n", "composite_event",
+            jcl_state.composite_event, eventCount.composite_event_count);
+        if (composite_event[0] & (1<<gmOffsetEvent)) {
+            printf("| - %-15s | %-12s | %-11s |\n", "offset_in_range", " ", " ");
+        }
+        if (composite_event[0] & (1<<servoLockedEvent)) {
+            printf("| - %-15s | %-12s | %-11s |\n", "servo_locked", " ", " ");
+        }
+        if (composite_event[0] & (1<<asCapableEvent)) {
+            printf("| - %-15s | %-12s | %-11s |\n", "as_Capable", " ", " ");
+        }
+        printf("+-------------------+--------------+-------------+\n\n");
         sleep(1);
     }
 

--- a/jclklib/common/jclklib_import.hpp
+++ b/jclklib/common/jclklib_import.hpp
@@ -140,12 +140,14 @@ enum servoState_e  {
 	private:
 		jcl_event        event;
 		jcl_value        value;
+		jcl_event        composite_event;
 	public:
 		std::uint8_t *parse(std::uint8_t *buf, std::size_t &length);
 		std::uint8_t *write(std::uint8_t *buf, std::size_t &length);
 
 		DECLARE_ACCESSOR(event);
 		DECLARE_ACCESSOR(value);
+		DECLARE_ACCESSOR(composite_event);
 	};
 
 	struct ptp_event {
@@ -167,11 +169,13 @@ enum servoState_e  {
 		int32_t gmPresent;
 		uint8_t servo_state;
 		uint8_t ptp4l_id;
+		bool composite_event;
 		std::atomic<int> offset_event_count{};
 		std::atomic<int> asCapable_event_count{};
 		std::atomic<int> servo_state_event_count{};
 		std::atomic<int> gmPresent_event_count{};
 		std::atomic<int> gmChanged_event_count{};
+		std::atomic<int> composite_event_count{};
 	};
 
 	struct jcl_state
@@ -181,6 +185,7 @@ enum servoState_e  {
 		bool     offset_in_range;
 		bool     servo_locked;
 		bool     gm_changed;
+		bool     composite_event;
 		uint8_t  gmIdentity[8];
 	};
 
@@ -191,6 +196,7 @@ enum servoState_e  {
 		uint64_t gm_changed_event_count;
 		uint64_t asCapable_event_count;
 		uint64_t servo_locked_event_count;
+		uint64_t composite_event_count;
 	};
 
 


### PR DESCRIPTION
Allow user to set composite event where they will only be notified whether all events are meet or at least one of the event is not meet.