### PR TITLE
jclklib: Fix proxy hang issue after client is terminated

### DIFF
--- a/jclklib/common/msgq_tport.cpp
+++ b/jclklib/common/msgq_tport.cpp
@@ -94,6 +94,7 @@ SEND_BUFFER_TYPE(MessageQueueTransmitterContext::sendBuffer)
 {
 	if (mq_send(mqTransmitterDesc, (char *)get_buffer().data(), get_offset(), 0) == -1) {
 		PrintErrorCode("Failed to send buffer");
+		mq_close(mqTransmitterDesc);
 		return false;
 	}
 

--- a/jclklib/proxy/msgq_tport.cpp
+++ b/jclklib/proxy/msgq_tport.cpp
@@ -51,7 +51,7 @@ LISTENER_CONTEXT_PROCESS_MESSAGE_TYPE(ProxyMessageQueueListenerContext::processM
 
 CREATE_TRANSMIT_CONTEXT_TYPE(ProxyMessageQueueListenerContext::CreateTransmitterContext)
 {
-	mqd_t txd = mq_open((char *)clientId.data(), TX_QUEUE_FLAGS);
+	mqd_t txd = mq_open((char *)clientId.data(), TX_QUEUE_FLAGS | O_NONBLOCK);
 	if (txd == -1) {
 		PrintErrorCode("Failed to open message queue " + string((const char*)clientId.data()));
 		return NULL;


### PR DESCRIPTION
Fix the issue that proxy is hang after client is terminated.
1. When client is terminated, proxy will return error:
![image](https://github.com/intel-staging/libptpmgmt_iaclocklib/assets/49394711/ed3b60e5-c777-4151-a842-cf575e41c1f3)

2. When client started again, the proxy is able to send the notification msg to client:
![image](https://github.com/intel-staging/libptpmgmt_iaclocklib/assets/49394711/69434e4c-0959-44df-9b86-adcce5d61ead)
