### PR TITLE
Add license header to md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: GFDL-1.3-no-invariants-or-later
+     SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation. All rights reserved. -->
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: GFDL-1.3-no-invariants-or-later
+     SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation. All rights reserved. -->
 # Contributing
 
 ### License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: GFDL-1.3-no-invariants-or-later
+     SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation. All rights reserved. -->
 # Security Policy
 Intel is committed to rapidly addressing security vulnerabilities affecting our customers and providing clear guidance on the solution, impact, severity and mitigation. 
 

--- a/jclklib/README_jclklib.md
+++ b/jclklib/README_jclklib.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: GFDL-1.3-no-invariants-or-later
+     SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation. All rights reserved. -->
 # JCLKLIB codeflow
 
 Jclklib is a 2-part implementation for C/C++ application to obtain

--- a/jclklib/TEST_jclklib.md
+++ b/jclklib/TEST_jclklib.md
@@ -1,3 +1,5 @@
+<!-- SPDX-License-Identifier: GFDL-1.3-no-invariants-or-later
+     SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation. All rights reserved. -->
 # The diagram of clockmanager(CM)  usage in system : 
 
 Test app <------> CM runtime lib (jclklib.so) <----------> jclklib_proxy <-----> libptpmgmt.so <-----> ptp4l


### PR DESCRIPTION
Add GFDL-1.3-no-invariants-or-later license header to all md documentation files.