### PR TITLE
jclklib: update new build steps in latest libptpmgmt code base

### DIFF
--- a/jclklib/TEST_jclklib.md
+++ b/jclklib/TEST_jclklib.md
@@ -40,6 +40,7 @@ Then we compile the clock manager inside the jclklib folder. This will give us :
 	Libtool-bin
 	
 	3. Run this at the github root directory to compile libptpmgmt :
+		autoheader
 		autoconf
 		./configure
 		make


### PR DESCRIPTION
In new code base, autoheader is needed.