### PR TITLE
Fix event count not updated properly

### DIFF
--- a/jclklib/client/init.cpp
+++ b/jclklib/client/init.cpp
@@ -231,5 +231,7 @@ int JClkLibClientApi::jcl_status_wait(int timeout, JClkLibCommon::jcl_state &jcl
 	/* Reset the atomic count by reducing the corresponding eventCount */
 	ClientSubscribeMessage::resetClientPtpEventStruct(appClientState.get_sessionId(), eventCount);
 
+	appClientState.set_eventStateCount(eventCount);
+
 	return true;
 }

--- a/jclklib/client/subscribe_msg.cpp
+++ b/jclklib/client/subscribe_msg.cpp
@@ -260,4 +260,10 @@ void ClientSubscribeMessage::resetClientPtpEventStruct(JClkLibCommon::sessionId_
 							std::memory_order_relaxed);
 	client_ptp_data->composite_event_count.fetch_sub(eventCount.composite_event_count,
 							std::memory_order_relaxed);
+
+	eventCount.offset_in_range_event_count = client_ptp_data->offset_event_count;
+	eventCount.asCapable_event_count = client_ptp_data->asCapable_event_count;
+	eventCount.servo_locked_event_count = client_ptp_data->servo_state_event_count;
+	eventCount.gm_changed_event_count = client_ptp_data->gmChanged_event_count;
+	eventCount.composite_event_count = client_ptp_data->composite_event_count;
 }


### PR DESCRIPTION
The event count is updated properly and the event_count shouldn't keep decreasing when master is terminated.
![image](https://github.com/intel-staging/libptpmgmt_iaclocklib/assets/49394711/86603d2b-bde7-4783-a720-fba2834677f3)
