### PR TITLE
Add null check for dynamic cast in check_proxy_liveness

### DIFF
--- a/jclklib/client/jclk_init.cpp
+++ b/jclklib/client/jclk_init.cpp
@@ -173,6 +173,11 @@ bool check_proxy_liveness(ClientState &appClientState, int timeout)
     Message0 connectMsg(new ClientConnectMessage());
     ClientConnectMessage *cmsg = dynamic_cast<decltype(cmsg)>(connectMsg.get());
 
+    if (cmsg == nullptr) {
+        PrintDebug("[CONNECT] Failed to cast to ClientConnectMessage");
+        return false;
+    }
+
     appClientState.set_connected(false);
     cmsg->setClientState(&appClientState);
     cmsg->set_sessionId(appClientState.get_sessionId());


### PR DESCRIPTION
This commit adds a null check for the dynamic cast of `connectMsg.get()` to `ClientConnectMessage` in the `check_proxy_liveness` function.

Previously, if the dynamic cast failed, the program would attempt to dereference a null pointer, leading to undefined behavior. With this change, if the dynamic cast fails, the function will print a debug message and return false, preventing the null pointer dereference.