### PR TITLE
jclklib: Fix client terminate under high load condition

### DIFF
--- a/jclklib/client/jclk_client_state.cpp
+++ b/jclklib/client/jclk_client_state.cpp
@@ -124,3 +124,13 @@ JClkLibCommon::jcl_subscription &ClientState::get_eventSub()
 {
     return eventSub;
 }
+
+void ClientState::set_last_notification_time(struct timespec newTime)
+{
+    last_notification_time = newTime;
+}
+
+struct timespec ClientState::get_last_notification_time()
+{
+    return last_notification_time;
+}

--- a/jclklib/client/jclk_client_state.hpp
+++ b/jclklib/client/jclk_client_state.hpp
@@ -51,6 +51,7 @@ namespace JClkLibClient {
         jcl_state eventState = {};
         jcl_state_event_count eventStateCount ={};
         JClkLibCommon::jcl_subscription eventSub ={};
+        struct timespec last_notification_time;
 
     public:
         ClientState();
@@ -66,6 +67,8 @@ namespace JClkLibClient {
         jcl_state &get_eventState();
         void set_eventStateCount(jcl_state_event_count eCount);
         void set_eventState(jcl_state eState);
+        void set_last_notification_time(struct timespec last_notification_time);
+        struct timespec get_last_notification_time();
         std::string toString();
         JClkLibCommon::jcl_subscription &get_eventSub();
         DECLARE_ACCESSOR(sessionId);

--- a/jclklib/client/notification_msg.cpp
+++ b/jclklib/client/notification_msg.cpp
@@ -104,6 +104,13 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
 
         ClientState *currentClientState = *it;
 
+        struct timespec last_notification_time;
+
+        if (clock_gettime(CLOCK_MONOTONIC, &last_notification_time) == -1)
+            PrintDebug("ClientNotificationMessage::processMessage clock_gettime failed.\n");
+        else
+            currentClientState->set_last_notification_time(last_notification_time);
+
         jcl_state &jclCurrentState =
             currentClientState->get_eventState();
         jcl_state_event_count &jclCurrentEventCount =


### PR DESCRIPTION
Steps to generate high load condition
1. add summary_interval -7 and logSyncInterval -7 in config file to make the ptp4l send more offset value in every second
![image](https://github.com/intel-staging/libptpmgmt_iaclocklib/assets/49394711/a087095b-142a-449c-b45d-3a4a5ce177a0)

2. remove sleep(idle_time) in sample/jclk_test.cpp to remove the wait time for the sample application
![image](https://github.com/intel-staging/libptpmgmt_iaclocklib/assets/49394711/72972cc7-6e23-4181-821c-c710dd90c8b6)

Tested with this patch and no client terminate issue observed under high load condition for long time.
![image](https://github.com/intel-staging/libptpmgmt_iaclocklib/assets/49394711/50cef3c1-8db5-4614-893d-3e3baee5ac59)
