### PR TITLE
jclklib: Refactor servo lock status assignment in event_handle

### DIFF
--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -9,6 +9,10 @@ Files: */changelog
 Copyright: 2021 © Erez Geva
 License: GFDL-1.3-no-invariants-or-later
 
+Files: jclklib/image/*.png
+Copyright: 2024 © Intel Corporation
+License: GFDL-1.3-no-invariants-or-later
+
 Files: debian/co* debian/source/format
 Copyright: 2021 © Erez Geva
 License: GPL-3.0-or-later

--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,7 @@ SRC_FILES_DIR:=$(wildcard scripts/* *.md t*/*.pl */*/*.m4 .reuse/* */gitlab*\
   t*/*.sh */*/*.sh swig/*.md swig/*/* */*.i */*/msgCall.i */*/warn.i man/*\
   $(PMC_DIR)/phc_ctl $(PMC_DIR)/*.[ch]* $(JSON_SRC)/* */Makefile w*/*/Makefile\
   $(JCLKLIB_SRC)/*.md $(JCLKLIB_SRC)/*/Makefile $(JCLKLIB_SRC)/*/*.[ch]*\
+  $(JCLKLIB_SRC)/image/*.png\
   */*/*test*/*.go LICENSES/* *.in tools/*.in) src/ver.h.in src/name.h.in\
   $(SRCS) $(HEADERS_SRCS) LICENSE $(MAKEFILE_LIST) credits
 ifeq ($(INSIDE_GIT),true)

--- a/jclklib/TEST_jclklib.md
+++ b/jclklib/TEST_jclklib.md
@@ -128,13 +128,13 @@ Options:
 -s subscribe_event_mask
     Default: 0xf
     Bit 0: gmOffsetEvent
-    Bit 1: servoLockedEvent
+    Bit 1: syncedToPrimaryClockEvent
     Bit 2: asCapableEvent
     Bit 3: gmChangedEvent
 -c composite_event_mask
     Default: 0x7
     Bit 0: gmOffsetEvent
-    Bit 1: servoLockedEvent
+    Bit 1: syncedToPrimaryClockEvent
     Bit 2: asCapableEvent
 -u upper master offset (ns)
     Default: 100000 ns
@@ -156,21 +156,21 @@ Upper Master Offset: 100000 ns
 Lower Master Offset: -100000 ns
 
 [jclklib][5754097.973] Obtained data from Subscription Event:
-+-------------------+--------------------+
-| Event             | Event Status       |
-+-------------------+--------------------+
-| offset_in_range   | 1                  |
-| servo_locked      | 1                  |
-| as_Capable        | 1                  |
-| gm_Changed        | 1                  |
-+-------------------+--------------------+
-| UUID              | 00a1c1.fffe.000000 |
-+-------------------+--------------------+
-| composite_event   | 1                  |
-| - offset_in_range |                    |
-| - servo_locked    |                    |
-| - as_Capable      |                    |
-+-------------------+--------------------+
++---------------------------+--------------------+
+| Event                     | Event Status       |
++---------------------------+--------------------+
+| offset_in_range           | 1                  |
+| synced_to_primary_clock   | 1                  |
+| as_capable                | 1                  |
+| gm_Changed                | 1                  |
++---------------------------+--------------------+
+| UUID                      | 00a1c1.fffe.000000 |
++---------------------------+--------------------+
+| composite_event           | 1                  |
+| - offset_in_range         |                    |
+| - synced_to_primary_clock |                    |
+| - as_capable              |                    |
++---------------------------+--------------------+
 
 ```
 

--- a/jclklib/client/jclk_client_state.cpp
+++ b/jclklib/client/jclk_client_state.cpp
@@ -115,7 +115,7 @@ string ClientState::toString()
     name += " as_capable = " + to_string(this->get_eventState().as_capable);
     name += " gm_changed = " + to_string(this->get_eventState().gm_changed);
     name += " offset_in_range = " + to_string(this->get_eventState().offset_in_range);
-    name += " servo_locked = " + to_string(this->get_eventState().servo_locked);
+    name += " synced_to_primary_clock = " + to_string(this->get_eventState().synced_to_primary_clock);
     name += "\n";
     return name;
 }

--- a/jclklib/client/jclk_client_state.hpp
+++ b/jclklib/client/jclk_client_state.hpp
@@ -28,7 +28,7 @@ namespace JClkLibClient {
         uint8_t  gm_identity[8];
         bool     as_capable;
         bool     offset_in_range;
-        bool     servo_locked;
+        bool     synced_to_primary_clock;
         bool     gm_changed;
         bool     composite_event;
     };
@@ -37,7 +37,7 @@ namespace JClkLibClient {
         uint64_t offset_in_range_event_count;
         uint64_t gm_changed_event_count;
         uint64_t as_capable_event_count;
-        uint64_t servo_locked_event_count;
+        uint64_t synced_to_primary_clock_event_count;
         uint64_t composite_event_count;
     };
 

--- a/jclklib/client/jclk_init.cpp
+++ b/jclklib/client/jclk_init.cpp
@@ -259,7 +259,7 @@ int JClkLibClientApi::jcl_status_wait(int timeout, jcl_state &jcl_state_ref,
         /* Check if any member of eventCount is non-zero */
         if (eventCount.offset_in_range_event_count ||
             eventCount.as_capable_event_count ||
-            eventCount.servo_locked_event_count ||
+            eventCount.synced_to_primary_clock_event_count ||
             eventCount.composite_event_count ||
             eventCount.gm_changed_event_count) {
             event_changes_detected = true;

--- a/jclklib/client/jclklib_client_api_c.cpp
+++ b/jclklib/client/jclklib_client_api_c.cpp
@@ -50,7 +50,7 @@ bool jcl_c_subscribe(jcl_c_client_ptr client_ptr,
 
     current_state->as_capable = state.as_capable;
     current_state->offset_in_range = state.offset_in_range;
-    current_state->servo_locked = state.servo_locked;
+    current_state->synced_to_primary_clock = state.synced_to_primary_clock;
     current_state->gm_changed = state.gm_changed;
     current_state->composite_event = state.composite_event;
 
@@ -73,7 +73,7 @@ int jcl_c_status_wait(jcl_c_client_ptr client_ptr, int timeout,
 
     current_state->as_capable = state.as_capable;
     current_state->offset_in_range = state.offset_in_range;
-    current_state->servo_locked = state.servo_locked;
+    current_state->synced_to_primary_clock = state.synced_to_primary_clock;
     current_state->gm_changed = state.gm_changed;
     current_state->composite_event = state.composite_event;
 
@@ -84,7 +84,7 @@ int jcl_c_status_wait(jcl_c_client_ptr client_ptr, int timeout,
     event_count->composite_event_count = eventCount.composite_event_count;
     event_count->gm_changed_event_count = eventCount.gm_changed_event_count;
     event_count->offset_in_range_event_count = eventCount.offset_in_range_event_count;
-    event_count->servo_locked_event_count = eventCount.servo_locked_event_count;
+    event_count->synced_to_primary_clock_event_count = eventCount.synced_to_primary_clock_event_count;
 
     return ret;
 }

--- a/jclklib/client/jclklib_client_api_c.h
+++ b/jclklib/client/jclklib_client_api_c.h
@@ -21,7 +21,7 @@ extern "C" {
 
 enum event_type {
     gmOffsetEvent,
-    servoLockedEvent,
+    syncedToPrimaryClockEvent,
     asCapableEvent,
     gmChangedEvent,
     eventLast
@@ -47,7 +47,7 @@ struct jcl_c_state {
     uint8_t gm_identity[8];
     bool    as_capable;
     bool    offset_in_range;
-    bool    servo_locked;
+    bool    synced_to_primary_clock;
     bool    gm_changed;
     bool    composite_event;
 };
@@ -56,7 +56,7 @@ struct jcl_c_event_count {
     uint64_t offset_in_range_event_count;
     uint64_t gm_changed_event_count;
     uint64_t as_capable_event_count;
-    uint64_t servo_locked_event_count;
+    uint64_t synced_to_primary_clock_event_count;
     uint64_t composite_event_count;
 };
 

--- a/jclklib/client/notification_msg.cpp
+++ b/jclklib/client/notification_msg.cpp
@@ -153,9 +153,9 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
             }
         }
 
-        if ((eventSub[0] & 1<<servoLockedEvent) && (proxy_data.servo_locked != client_ptp_data->servo_locked)) {
-            client_ptp_data->servo_locked = proxy_data.servo_locked;
-            client_ptp_data->servo_locked_event_count.fetch_add(1, std::memory_order_relaxed);
+        if ((eventSub[0] & 1<<syncedToPrimaryClockEvent) && (proxy_data.synced_to_primary_clock != client_ptp_data->synced_to_primary_clock)) {
+            client_ptp_data->synced_to_primary_clock = proxy_data.synced_to_primary_clock;
+            client_ptp_data->synced_to_primary_clock_event_count.fetch_add(1, std::memory_order_relaxed);
         }
 
         if ((eventSub[0] & 1<<gmChangedEvent) &&
@@ -187,8 +187,8 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
             }
         }
 
-        if (composite_eventSub[0] & 1<<servoLockedEvent)
-            composite_client_ptp_data->composite_event &= proxy_data.servo_locked;
+        if (composite_eventSub[0] & 1<<syncedToPrimaryClockEvent)
+            composite_client_ptp_data->composite_event &= proxy_data.synced_to_primary_clock;
 
         if (composite_eventSub[0] & 1<<asCapableEvent)
             composite_client_ptp_data->composite_event &= proxy_data.as_capable;
@@ -198,13 +198,13 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
 
         jclCurrentState.as_capable = client_ptp_data->as_capable;
         jclCurrentState.offset_in_range = client_ptp_data->master_offset_in_range;
-        jclCurrentState.servo_locked = client_ptp_data->servo_locked;
+        jclCurrentState.synced_to_primary_clock = client_ptp_data->synced_to_primary_clock;
         jclCurrentState.composite_event = composite_client_ptp_data->composite_event;
         memcpy(jclCurrentState.gm_identity, client_ptp_data->gm_identity, sizeof(client_ptp_data->gm_identity));
 
         jclCurrentEventCount.offset_in_range_event_count = client_ptp_data->offset_in_range_event_count;
         jclCurrentEventCount.as_capable_event_count = client_ptp_data->as_capable_event_count;
-        jclCurrentEventCount.servo_locked_event_count = client_ptp_data->servo_locked_event_count;
+        jclCurrentEventCount.synced_to_primary_clock_event_count = client_ptp_data->synced_to_primary_clock_event_count;
         jclCurrentEventCount.gm_changed_event_count = client_ptp_data->gm_changed_event_count;
         jclCurrentEventCount.composite_event_count = client_ptp_data->composite_event_count;
     }

--- a/jclklib/client/subscribe_msg.cpp
+++ b/jclklib/client/subscribe_msg.cpp
@@ -108,8 +108,8 @@ PARSE_RXBUFFER_TYPE(ClientSubscribeMessage::parseBuffer)
             client_data->master_offset_in_range = true;
     }
 
-    if ((eventSub[0] & 1<<servoLockedEvent) && (data.servo_locked != client_data->servo_locked))
-        client_data->servo_locked = data.servo_locked;
+    if ((eventSub[0] & 1<<syncedToPrimaryClockEvent) && (data.synced_to_primary_clock != client_data->synced_to_primary_clock))
+        client_data->synced_to_primary_clock = data.synced_to_primary_clock;
 
     if ((eventSub[0] & 1<<gmChangedEvent) &&
         (memcmp(client_data->gm_identity, data.gm_identity, sizeof(data.gm_identity))) != 0) {
@@ -133,15 +133,15 @@ PARSE_RXBUFFER_TYPE(ClientSubscribeMessage::parseBuffer)
             composite_client_data->composite_event = false;
     }
 
-    if (composite_eventSub[0] & 1<<servoLockedEvent)
-        composite_client_data->composite_event &= data.servo_locked;
+    if (composite_eventSub[0] & 1<<syncedToPrimaryClockEvent)
+        composite_client_data->composite_event &= data.synced_to_primary_clock;
 
     if (composite_eventSub[0] & 1<<asCapableEvent)
         composite_client_data->composite_event &= data.as_capable;
 
     jclCurrentState->as_capable = client_data->as_capable;
     jclCurrentState->offset_in_range = client_data->master_offset_in_range;
-    jclCurrentState->servo_locked = client_data->servo_locked;
+    jclCurrentState->synced_to_primary_clock = client_data->synced_to_primary_clock;
     jclCurrentState->composite_event = composite_client_data->composite_event;
     memcpy(jclCurrentState->gm_identity, client_data->gm_identity, sizeof(client_data->gm_identity));
 	
@@ -245,7 +245,7 @@ void ClientSubscribeMessage::resetClientPtpEventStruct(JClkLibCommon::sessionId_
         std::memory_order_relaxed);
     client_ptp_data->as_capable_event_count.fetch_sub(eventCount.as_capable_event_count,
         std::memory_order_relaxed);
-    client_ptp_data->servo_locked_event_count.fetch_sub(eventCount.servo_locked_event_count,
+    client_ptp_data->synced_to_primary_clock_event_count.fetch_sub(eventCount.synced_to_primary_clock_event_count,
         std::memory_order_relaxed);
     client_ptp_data->gm_changed_event_count.fetch_sub(eventCount.gm_changed_event_count,
         std::memory_order_relaxed);
@@ -254,7 +254,7 @@ void ClientSubscribeMessage::resetClientPtpEventStruct(JClkLibCommon::sessionId_
 
     eventCount.offset_in_range_event_count = client_ptp_data->offset_in_range_event_count;
     eventCount.as_capable_event_count = client_ptp_data->as_capable_event_count;
-    eventCount.servo_locked_event_count = client_ptp_data->servo_locked_event_count;
+    eventCount.synced_to_primary_clock_event_count = client_ptp_data->synced_to_primary_clock_event_count;
     eventCount.gm_changed_event_count = client_ptp_data->gm_changed_event_count;
     eventCount.composite_event_count = client_ptp_data->composite_event_count;
 }

--- a/jclklib/common/jclklib_import.hpp
+++ b/jclklib/common/jclklib_import.hpp
@@ -70,7 +70,7 @@ namespace JClkLibCommon
 
     /* Events clients can subscribe to */
     typedef enum : std::uint8_t
-        { gmOffsetEvent, servoLockedEvent, asCapableEvent, gmChangedEvent,
+        { gmOffsetEvent, syncedToPrimaryClockEvent, asCapableEvent, gmChangedEvent,
             eventLast } eventType;
 
 #define BITS_PER_BYTE (8)
@@ -126,7 +126,7 @@ namespace JClkLibCommon
         int64_t master_offset;
         uint8_t gm_identity[8]; /* Grandmaster clock ID */
         bool as_capable; /* 802@.1AS Capable */
-        bool servo_locked;
+        bool synced_to_primary_clock;
         uint8_t ptp4l_id;
     };
 
@@ -137,12 +137,12 @@ namespace JClkLibCommon
         uint8_t gm_identity[8]; /* Grandmaster clock ID */
         uint8_t ptp4l_id;
         bool as_capable; /* 802@.1AS Capable */
-        bool servo_locked;
+        bool synced_to_primary_clock;
         bool master_offset_in_range;
         bool composite_event;
         std::atomic<int> offset_in_range_event_count{};
         std::atomic<int> as_capable_event_count{};
-        std::atomic<int> servo_locked_event_count{};
+        std::atomic<int> synced_to_primary_clock_event_count{};
         std::atomic<int> gm_changed_event_count{};
         std::atomic<int> composite_event_count{};
     };

--- a/jclklib/proxy/connect_ptp4l.cpp
+++ b/jclklib/proxy/connect_ptp4l.cpp
@@ -200,6 +200,7 @@ static inline bool msg_set_action(bool local, mng_vals_e id)
 bool event_subscription(struct jcl_handle **handle)
 {
     memset(d.bitmask, 0, sizeof d.bitmask);
+    d.duration = UINT16_MAX;
     d.setEvent(NOTIFY_TIME_SYNC);
     d.setEvent(NOTIFY_PORT_STATE);
     d.setEvent(NOTIFY_CMLDS);

--- a/jclklib/proxy/thread.hpp
+++ b/jclklib/proxy/thread.hpp
@@ -49,7 +49,7 @@ struct ptp4l_state {
     unsigned valid_mask;
     bool peer_present;
     unsigned offset;
-    bool servo_locked;
+    bool synced_to_primary_clock;
 };
 
 int handle_connect(struct epoll_event epd_event );

--- a/jclklib/sample/jclk_c_test.c
+++ b/jclklib/sample/jclk_c_test.c
@@ -49,10 +49,10 @@ int main(int argc, char *argv[])
     int retval;
     int opt;
 
-    subscription.event[0] = ((1<<gmOffsetEvent) | (1<<servoLockedEvent) |
+    subscription.event[0] = ((1<<gmOffsetEvent) | (1<<syncedToPrimaryClockEvent) |
         (1<<asCapableEvent) | (1<<gmChangedEvent));
     subscription.composite_event[0] = ((1<<gmOffsetEvent) |
-        (1<<servoLockedEvent) | (1<<asCapableEvent));
+        (1<<syncedToPrimaryClockEvent) | (1<<asCapableEvent));
     subscription.value[gm_offset].upper = 100000;
     subscription.value[gm_offset].lower = -100000;
 
@@ -82,13 +82,13 @@ int main(int argc, char *argv[])
                    "  -s subscribe_event_mask\n"
                    "     Default: 0x%x\n"
                    "     Bit 0: gmOffsetEvent\n"
-                   "     Bit 1: servoLockedEvent\n"
+                   "     Bit 1: syncedToPrimaryClockEvent\n"
                    "     Bit 2: asCapableEvent\n"
                    "     Bit 3: gmChangedEvent\n"
                    "  -c composite_event_mask\n"
                    "     Default: 0x%x\n"
                    "     Bit 0: gmOffsetEvent\n"
-                   "     Bit 1: servoLockedEvent\n"
+                   "     Bit 1: syncedToPrimaryClockEvent\n"
                    "     Bit 2: asCapableEvent\n"
                    "  -u upper master offset (ns)\n"
                    "     Default: %d ns\n"
@@ -109,13 +109,13 @@ int main(int argc, char *argv[])
                    "  -s subscribe_event_mask\n"
                    "     Default: 0x%x\n"
                    "     Bit 0: gmOffsetEvent\n"
-                   "     Bit 1: servoLockedEvent\n"
+                   "     Bit 1: syncedToPrimaryClockEvent\n"
                    "     Bit 2: asCapableEvent\n"
                    "     Bit 3: gmChangedEvent\n"
                    "  -c composite_event_mask\n"
                    "     Default: 0x%x\n"
                    "     Bit 0: gmOffsetEvent\n"
-                   "     Bit 1: servoLockedEvent\n"
+                   "     Bit 1: syncedToPrimaryClockEvent\n"
                    "     Bit 2: asCapableEvent\n"
                    "  -u upper master offset (ns)\n"
                    "     Default: %d ns\n"
@@ -155,46 +155,46 @@ int main(int argc, char *argv[])
 
     printf("[jclklib][%.3f] Obtained data from Subscription Event:\n",
         getMonotonicTime());
-    printf("+-------------------+--------------------+\n");
-    printf("| %-17s | %-18s |\n", "Event", "Event Status");
+    printf("+---------------------------+--------------------+\n");
+    printf("| %-25s | %-18s |\n", "Event", "Event Status");
     if (subscription.event[0]) {
-        printf("+-------------------+--------------------+\n");
+        printf("+---------------------------+--------------------+\n");
     }
     if (subscription.event[0] & (1<<gmOffsetEvent)) {
-        printf("| %-17s | %-18d |\n", "offset_in_range",
+        printf("| %-25s | %-18d |\n", "offset_in_range",
             state.offset_in_range);
     }
-    if (subscription.event[0] & (1<<servoLockedEvent)) {
-        printf("| %-17s | %-18d |\n", "servo_locked", state.servo_locked);
+    if (subscription.event[0] & (1<<syncedToPrimaryClockEvent)) {
+        printf("| %-25s | %-18d |\n", "synced_to_primary_clock", state.synced_to_primary_clock);
     }
     if (subscription.event[0] & (1<<asCapableEvent)) {
-        printf("| %-17s | %-18d |\n", "as_capable", state.as_capable);
+        printf("| %-25s | %-18d |\n", "as_capable", state.as_capable);
     }
     if (subscription.event[0] & (1<<gmChangedEvent)) {
-        printf("| %-17s | %-18d |\n", "gm_Changed", state.gm_changed);
-        printf("+-------------------+--------------------+\n");
-        printf("| %-17s | %02x%02x%02x.%02x%02x.%02x%02x%02x |\n", "UUID",
+        printf("| %-25s | %-18d |\n", "gm_Changed", state.gm_changed);
+        printf("+---------------------------+--------------------+\n");
+        printf("| %-25s | %02x%02x%02x.%02x%02x.%02x%02x%02x |\n", "UUID",
             state.gm_identity[0], state.gm_identity[1],
             state.gm_identity[2], state.gm_identity[3],
             state.gm_identity[4], state.gm_identity[5],
             state.gm_identity[6], state.gm_identity[7]);
     }
-    printf("+-------------------+--------------------+\n");
+    printf("+---------------------------+--------------------+\n");
     if (subscription.composite_event[0]) {
-        printf("| %-17s | %-18d |\n", "composite_event",
+        printf("| %-25s | %-18d |\n", "composite_event",
             state.composite_event);
     }
     if (subscription.composite_event[0] & (1<<gmOffsetEvent)) {
-        printf("| - %-15s | %-18s |\n", "offset_in_range", " ");
+        printf("| - %-23s | %-18s |\n", "offset_in_range", " ");
     }
-    if (subscription.composite_event[0] & (1<<servoLockedEvent)) {
-        printf("| - %-15s | %-18s |\n", "servo_locked", " ");
+    if (subscription.composite_event[0] & (1<<syncedToPrimaryClockEvent)) {
+        printf("| - %-19s | %-18s |\n", "synced_to_primary_clock", " ");
     }
     if (subscription.composite_event[0] & (1<<asCapableEvent)) {
-        printf("| - %-15s | %-18s |\n", "as_capable", " ");
+        printf("| - %-23s | %-18s |\n", "as_capable", " ");
     }
     if (subscription.composite_event[0]) {
-        printf("+-------------------+--------------------+\n\n");
+        printf("+---------------------------+--------------------+\n\n");
     } else {
         printf("\n");
     }
@@ -220,51 +220,51 @@ int main(int argc, char *argv[])
 
         printf("[jclklib][%.3f] Obtained data from Notification Event:\n",
             getMonotonicTime());
-        printf("+-------------------+--------------+-------------+\n");
-        printf("| %-17s | %-12s | %-11s |\n", "Event", "Event Status",
+        printf("+---------------------------+--------------+-------------+\n");
+        printf("| %-25s | %-12s | %-11s |\n", "Event", "Event Status",
             "Event Count");
         if (subscription.event[0]) {
-        printf("+-------------------+--------------+-------------+\n");
+        printf("+---------------------------+--------------+-------------+\n");
         }
         if (subscription.event[0] & (1<<gmOffsetEvent)) {
-            printf("| %-17s | %-12d | %-11ld |\n", "offset_in_range",
+            printf("| %-25s | %-12d | %-11ld |\n", "offset_in_range",
                 state.offset_in_range,
                 event_count.offset_in_range_event_count);
         }
-        if (subscription.event[0] & (1<<servoLockedEvent)) {
-            printf("| %-17s | %-12d | %-11ld |\n", "servo_locked",
-               state.servo_locked, event_count.servo_locked_event_count);
+        if (subscription.event[0] & (1<<syncedToPrimaryClockEvent)) {
+            printf("| %-25s | %-12d | %-11ld |\n", "synced_to_primary_clock",
+               state.synced_to_primary_clock, event_count.synced_to_primary_clock_event_count);
         }
         if (subscription.event[0] & (1<<asCapableEvent)) {
-            printf("| %-17s | %-12d | %-11ld |\n", "as_capable",
+            printf("| %-25s | %-12d | %-11ld |\n", "as_capable",
                 state.as_capable, event_count.as_capable_event_count);
         }
         if (subscription.event[0] & (1<<gmChangedEvent)) {
-            printf("| %-17s | %-12d | %-11ld |\n", "gm_Changed",
+            printf("| %-25s | %-12d | %-11ld |\n", "gm_Changed",
                 state.gm_changed, event_count.gm_changed_event_count);
-            printf("+-------------------+--------------+-------------+\n");
-            printf("| %-17s |     %02x%02x%02x.%02x%02x.%02x%02x%02x     |\n",
+            printf("+---------------------------+--------------+-------------+\n");
+            printf("| %-25s |     %02x%02x%02x.%02x%02x.%02x%02x%02x     |\n",
                 "UUID", state.gm_identity[0], state.gm_identity[1],
                 state.gm_identity[2], state.gm_identity[3],
                 state.gm_identity[4], state.gm_identity[5],
                 state.gm_identity[6], state.gm_identity[7]);
         }
-        printf("+-------------------+--------------+-------------+\n");
+        printf("+---------------------------+--------------+-------------+\n");
         if (subscription.composite_event[0]) {
-            printf("| %-17s | %-12d | %-11ld |\n", "composite_event",
+            printf("| %-25s | %-12d | %-11ld |\n", "composite_event",
                    state.composite_event, event_count.composite_event_count);
         }
         if (subscription.composite_event[0] & (1<<gmOffsetEvent)) {
-            printf("| - %-15s | %-12s | %-11s |\n", "offset_in_range", "", "");
+            printf("| - %-23s | %-12s | %-11s |\n", "offset_in_range", "", "");
         }
-        if (subscription.composite_event[0] & (1<<servoLockedEvent)) {
-            printf("| - %-15s | %-12s | %-11s |\n", "servo_locked", "", "");
+        if (subscription.composite_event[0] & (1<<syncedToPrimaryClockEvent)) {
+            printf("| - %-19s | %-12s | %-11s |\n", "synced_to_primary_clock", "", "");
         }
         if (subscription.composite_event[0] & (1<<asCapableEvent)) {
-            printf("| - %-15s | %-12s | %-11s |\n", "as_capable", "", "");
+            printf("| - %-23s | %-12s | %-11s |\n", "as_capable", "", "");
         }
         if (subscription.composite_event[0]) {
-            printf("+-------------------+--------------+-------------+\n\n");
+            printf("+---------------------------+--------------+-------------+\n\n");
         } else {
             printf("\n");
         }

--- a/jclklib/sample/jclk_test.cpp
+++ b/jclklib/sample/jclk_test.cpp
@@ -62,12 +62,12 @@ int main(int argc, char *argv[])
     int opt;
 
     std::uint32_t event2Sub1[1] = {
-        ((1<<gmOffsetEvent) | (1<<servoLockedEvent) | (1<<asCapableEvent) |
+        ((1<<gmOffsetEvent) | (1<<syncedToPrimaryClockEvent) | (1<<asCapableEvent) |
         (1<<gmChangedEvent))
     };
 
     std::uint32_t composite_event[1] = {
-        ((1<<gmOffsetEvent) | (1<<servoLockedEvent) | (1<<asCapableEvent))
+        ((1<<gmOffsetEvent) | (1<<syncedToPrimaryClockEvent) | (1<<asCapableEvent))
     };
 
     while ((opt = getopt(argc, argv, "s:c:u:l:i:t:h")) != -1) {
@@ -96,13 +96,13 @@ int main(int argc, char *argv[])
                 "  -s subscribe_event_mask\n"
                 "     Default: 0x" << std::hex << event2Sub1[0] << "\n"
                 "     Bit 0: gmOffsetEvent\n"
-                "     Bit 1: servoLockedEvent\n"
+                "     Bit 1: syncedToPrimaryClockEvent\n"
                 "     Bit 2: asCapableEvent\n"
                 "     Bit 3: gmChangedEvent\n"
                 "  -c composite_event_mask\n"
                 "     Default: 0x" << composite_event[0] << "\n"
                 "     Bit 0: gmOffsetEvent\n"
-                "     Bit 1: servoLockedEvent\n"
+                "     Bit 1: syncedToPrimaryClockEvent\n"
                 "     Bit 2: asCapableEvent\n"
                 "  -u upper master offset (ns)\n"
                 "     Default: " << std::dec << upper_master_offset << " ns\n"
@@ -119,13 +119,13 @@ int main(int argc, char *argv[])
                 "  -s subscribe_event_mask\n"
                 "     Default: 0x" << std::hex << event2Sub1[0] << "\n"
                 "     Bit 0: gmOffsetEvent\n"
-                "     Bit 1: servoLockedEvent\n"
+                "     Bit 1: syncedToPrimaryClockEvent\n"
                 "     Bit 2: asCapableEvent\n"
                 "     Bit 3: gmChangedEvent\n"
                 "  -c composite_event_mask\n"
                 "     Default: 0x" << composite_event[0] << "\n"
                 "     Bit 0: gmOffsetEvent\n"
-                "     Bit 1: servoLockedEvent\n"
+                "     Bit 1: syncedToPrimaryClockEvent\n"
                 "     Bit 2: asCapableEvent\n"
                 "  -u upper master offset (ns)\n"
                 "     Default: " << std::dec << upper_master_offset << " ns\n"
@@ -180,46 +180,46 @@ int main(int argc, char *argv[])
 
     printf("[jclklib][%.3f] Obtained data from Subscription Event:\n",
         getMonotonicTime());
-    printf("+-------------------+--------------------+\n");
-    printf("| %-17s | %-18s |\n", "Event", "Event Status");
+    printf("+---------------------------+--------------------+\n");
+    printf("| %-25s | %-18s |\n", "Event", "Event Status");
     if (event2Sub1[0]) {
-        printf("+-------------------+--------------------+\n");
+        printf("+---------------------------+--------------------+\n");
     }
     if (event2Sub1[0] & (1<<gmOffsetEvent)) {
-        printf("| %-17s | %-18d |\n", "offset_in_range",
+        printf("| %-25s | %-18d |\n", "offset_in_range",
             state.offset_in_range);
     }
-    if (event2Sub1[0] & (1<<servoLockedEvent)) {
-        printf("| %-17s | %-18d |\n", "servo_locked", state.servo_locked);
+    if (event2Sub1[0] & (1<<syncedToPrimaryClockEvent)) {
+        printf("| %-25s | %-18d |\n", "synced_to_primary_clock", state.synced_to_primary_clock);
     }
     if (event2Sub1[0] & (1<<asCapableEvent)) {
-        printf("| %-17s | %-18d |\n", "as_capable", state.as_capable);
+        printf("| %-25s | %-18d |\n", "as_capable", state.as_capable);
     }
     if (event2Sub1[0] & (1<<gmChangedEvent)) {
-        printf("| %-17s | %-18d |\n", "gm_Changed", state.gm_changed);
-        printf("+-------------------+--------------------+\n");
-        printf("| %-17s | %02x%02x%02x.%02x%02x.%02x%02x%02x |\n", "UUID",
+        printf("| %-25s | %-18d |\n", "gm_Changed", state.gm_changed);
+        printf("+---------------------------+--------------------+\n");
+        printf("| %-25s | %02x%02x%02x.%02x%02x.%02x%02x%02x |\n", "UUID",
             state.gm_identity[0], state.gm_identity[1],
             state.gm_identity[2], state.gm_identity[3],
             state.gm_identity[4], state.gm_identity[5],
             state.gm_identity[6], state.gm_identity[7]);
     }
-    printf("+-------------------+--------------------+\n");
+    printf("+---------------------------+--------------------+\n");
     if (composite_event[0]) {
-        printf("| %-17s | %-18d |\n", "composite_event",
+        printf("| %-25s | %-18d |\n", "composite_event",
             state.composite_event);
     }
     if (composite_event[0] & (1<<gmOffsetEvent)) {
-        printf("| - %-15s | %-18s |\n", "offset_in_range", " ");
+        printf("| - %-23s | %-18s |\n", "offset_in_range", " ");
     }
-    if (composite_event[0] & (1<<servoLockedEvent)) {
-        printf("| - %-15s | %-18s |\n", "servo_locked", " ");
+    if (composite_event[0] & (1<<syncedToPrimaryClockEvent)) {
+        printf("| - %-19s | %-18s |\n", "synced_to_primary_clock", " ");
     }
     if (composite_event[0] & (1<<asCapableEvent)) {
-        printf("| - %-15s | %-18s |\n", "as_capable", " ");
+        printf("| - %-23s | %-18s |\n", "as_capable", " ");
     }
     if (composite_event[0]) {
-        printf("+-------------------+--------------------+\n\n");
+        printf("+---------------------------+--------------------+\n\n");
     } else {
         printf("\n");
     }
@@ -245,51 +245,51 @@ int main(int argc, char *argv[])
 
         printf("[jclklib][%.3f] Obtained data from Notification Event:\n",
             getMonotonicTime());
-        printf("+-------------------+--------------+-------------+\n");
-        printf("| %-17s | %-12s | %-11s |\n", "Event", "Event Status",
+        printf("+---------------------------+--------------+-------------+\n");
+        printf("| %-25s | %-12s | %-11s |\n", "Event", "Event Status",
             "Event Count");
         if (event2Sub1[0]) {
-        printf("+-------------------+--------------+-------------+\n");
+        printf("+---------------------------+--------------+-------------+\n");
         }
         if (event2Sub1[0] & (1<<gmOffsetEvent)) {
-            printf("| %-17s | %-12d | %-11ld |\n", "offset_in_range",
+            printf("| %-25s | %-12d | %-11ld |\n", "offset_in_range",
                 state.offset_in_range,
                 eventCount.offset_in_range_event_count);
         }
-        if (event2Sub1[0] & (1<<servoLockedEvent)) {
-            printf("| %-17s | %-12d | %-11ld |\n", "servo_locked",
-               state.servo_locked, eventCount.servo_locked_event_count);
+        if (event2Sub1[0] & (1<<syncedToPrimaryClockEvent)) {
+            printf("| %-25s | %-12d | %-11ld |\n", "synced_to_primary_clock",
+               state.synced_to_primary_clock, eventCount.synced_to_primary_clock_event_count);
         }
         if (event2Sub1[0] & (1<<asCapableEvent)) {
-            printf("| %-17s | %-12d | %-11ld |\n", "as_capable",
+            printf("| %-25s | %-12d | %-11ld |\n", "as_capable",
                 state.as_capable, eventCount.as_capable_event_count);
         }
         if (event2Sub1[0] & (1<<gmChangedEvent)) {
-            printf("| %-17s | %-12d | %-11ld |\n", "gm_Changed",
+            printf("| %-25s | %-12d | %-11ld |\n", "gm_Changed",
                 state.gm_changed, eventCount.gm_changed_event_count);
-            printf("+-------------------+--------------+-------------+\n");
-            printf("| %-17s |     %02x%02x%02x.%02x%02x.%02x%02x%02x     |\n",
+            printf("+---------------------------+--------------+-------------+\n");
+            printf("| %-25s |     %02x%02x%02x.%02x%02x.%02x%02x%02x     |\n",
                 "UUID", state.gm_identity[0], state.gm_identity[1],
                 state.gm_identity[2], state.gm_identity[3],
                 state.gm_identity[4], state.gm_identity[5],
                 state.gm_identity[6], state.gm_identity[7]);
         }
-        printf("+-------------------+--------------+-------------+\n");
+        printf("+---------------------------+--------------+-------------+\n");
         if (composite_event[0]) {
-            printf("| %-17s | %-12d | %-11ld |\n", "composite_event",
+            printf("| %-25s | %-12d | %-11ld |\n", "composite_event",
                    state.composite_event, eventCount.composite_event_count);
         }
         if (composite_event[0] & (1<<gmOffsetEvent)) {
-            printf("| - %-15s | %-12s | %-11s |\n", "offset_in_range", "", "");
+            printf("| - %-23s | %-12s | %-11s |\n", "offset_in_range", "", "");
         }
-        if (composite_event[0] & (1<<servoLockedEvent)) {
-            printf("| - %-15s | %-12s | %-11s |\n", "servo_locked", "", "");
+        if (composite_event[0] & (1<<syncedToPrimaryClockEvent)) {
+            printf("| - %-19s | %-12s | %-11s |\n", "synced_to_primary_clock", "", "");
         }
         if (composite_event[0] & (1<<asCapableEvent)) {
-            printf("| - %-15s | %-12s | %-11s |\n", "as_capable", "", "");
+            printf("| - %-23s | %-12s | %-11s |\n", "as_capable", "", "");
         }
         if (composite_event[0]) {
-            printf("+-------------------+--------------+-------------+\n\n");
+            printf("+---------------------------+--------------+-------------+\n\n");
         } else {
             printf("\n");
         }

--- a/ptp-tools/pmc_dump.cpp
+++ b/ptp-tools/pmc_dump.cpp
@@ -358,8 +358,7 @@ class MsgDump : public MessageDispatcher
             IDENT "gmTimeBaseIndicator        %u"
             IDENT "lastGmPhaseChange          0x%04hx'%016jd.%04hx"
             IDENT "gmPresent                  %s"
-            IDENT "gmIdentity                 %s"
-            IDENT "servo_state                %s",
+            IDENT "gmIdentity                 %s",
             d.master_offset,
             d.ingress_time,
             (float_nanoseconds)d.cumulativeScaledRateOffset / P41,
@@ -370,8 +369,7 @@ class MsgDump : public MessageDispatcher
             d.nanoseconds_lsb,
             d.fractional_nanoseconds,
             d.gmPresent ? "true" : "false",
-            d.gmIdentity.string().c_str(),
-            m.servo2str_c(d.servo_state));
+            d.gmIdentity.string().c_str());
     }
     dump(GRANDMASTER_SETTINGS_NP) {
         DUMPS(

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -357,8 +357,7 @@ JS(TIME_STATUS_NP)
         PROC_VAL(nanoseconds_lsb) &&
         PROC_VAL(fractional_nanoseconds) &&
         PROC_VAL(gmPresent) &&
-        PROC_VAL(gmIdentity) &&
-        PROC_VAL(servo_state);
+        PROC_VAL(gmIdentity);
 }
 JS(GRANDMASTER_SETTINGS_NP)
 {

--- a/src/proc.cpp
+++ b/src/proc.cpp
@@ -812,7 +812,7 @@ A(TIME_STATUS_NP)
         proc(d.scaledLastGmPhaseChange) || proc(d.gmTimeBaseIndicator) ||
         proc(d.nanoseconds_msb) || proc(d.nanoseconds_lsb) ||
         proc(d.fractional_nanoseconds) || proc(d.gmPresent) ||
-        proc(d.gmIdentity) || proc(d.servo_state);
+        proc(d.gmIdentity);
 }
 A(GRANDMASTER_SETTINGS_NP)
 {
@@ -1225,7 +1225,6 @@ C1(TIME_STATUS_NP)
     a.fractional_nanoseconds = d.fractional_nanoseconds;
     a.gmPresent = d.gmPresent;
     memcpy(a.gmIdentity.v, d.gmIdentity.v, ClockIdentity_t::size());
-    a.servo_state = (ptpmgmt_servoState_e)d.servo_state;
 }
 C1(GRANDMASTER_SETTINGS_NP)
 {
@@ -1714,7 +1713,6 @@ C2(TIME_STATUS_NP)
     a.fractional_nanoseconds = d.fractional_nanoseconds;
     a.gmPresent = d.gmPresent;
     memcpy(a.gmIdentity.v, d.gmIdentity.v, ClockIdentity_t::size());
-    a.servo_state = (servoState_e)d.servo_state;
 }
 C2(GRANDMASTER_SETTINGS_NP)
 {

--- a/src/proc.m4
+++ b/src/proc.m4
@@ -441,7 +441,6 @@ strc(TIME_STATUS_NP_t) sz(: public BaseMngTlv) {
     uint16_t fractional_nanoseconds;
     Integer32_t gmPresent; /**< Flag for grandmaster presence */
     strcc(ClockIdentity_t) gmIdentity; /**< Grandmaster clock ID */
-    enmc(servoState_e) servo_state; /**< Servo state */
 };
 /** Grandmaster settings TLV
  * @note linuxptp implementation specific
@@ -480,10 +479,6 @@ cnst_st() int NM(NOTIFY_TIME_SYNC) = 1;
 cnst_st() int NM(NOTIFY_PARENT_DATA_SET) = 2;
 /** Notify Common Mean Link Delay Information in SUBSCRIBE_EVENTS_NP.bitmask */
 cnst_st() int NM(NOTIFY_CMLDS) = 3;
-/** Notify NP parent state offset in SUBSCRIBE_EVENTS_NP.bitmask */
-cnst_st() int NM(NOTIFY_PORT_STATE_NP) = 4;
-/** Notify all event in SUBSCRIBE_EVENTS_NP.bitmask */
-cnst_st() int NM(NOTIFY_ALL) = 5;
 /** Subscribe events TLV
  * @note linuxptp implementation specific
  */

--- a/uctest/json2msg.c
+++ b/uctest/json2msg.c
@@ -1981,8 +1981,7 @@ Test(Json2msgTest, TIME_STATUS_NP)
             "\"nanoseconds_lsb\":0,"
             "\"fractional_nanoseconds\":0,"
             "\"gmPresent\":0,"
-            "\"gmIdentity\":\"c47d46.fffe.20acae\","
-            "\"servo_state\":\"SERVO_UNLOCKED\""
+            "\"gmIdentity\":\"c47d46.fffe.20acae\""
             "}}"));
     cr_expect(eq(int, m->actionField(m), PTPMGMT_SET));
     cr_expect(eq(int, m->managementId(m), PTPMGMT_TIME_STATUS_NP));
@@ -2000,7 +1999,6 @@ Test(Json2msgTest, TIME_STATUS_NP)
     cr_expect(eq(int, t->fractional_nanoseconds, 0));
     cr_expect(eq(int, t->gmPresent, 0));
     cr_expect(zero(memcmp(t->gmIdentity.v, clockId, 8)));
-    cr_expect(eq(u8, t->servo_state, PTPMGMT_SERVO_UNLOCKED));
     m->free(m);
 }
 

--- a/uctest/msg2json.c
+++ b/uctest/msg2json.c
@@ -1623,7 +1623,6 @@ Test(Tlv2JsonTest, TIME_STATUS_NP)
     t.gmIdentity.v[5] = 32;
     t.gmIdentity.v[6] = 172;
     t.gmIdentity.v[7] = 174;
-    t.servo_state = PTPMGMT_SERVO_UNLOCKED;
     char *ret = ptpmgmt_json_tlv2json(PTPMGMT_TIME_STATUS_NP, &t, 0);
     cr_assert(not(zero(ptr, ret)));
     cr_assert(eq(str, (char *)ret,
@@ -1637,8 +1636,7 @@ Test(Tlv2JsonTest, TIME_STATUS_NP)
             "  \"nanoseconds_lsb\" : 0,\n"
             "  \"fractional_nanoseconds\" : 0,\n"
             "  \"gmPresent\" : 0,\n"
-            "  \"gmIdentity\" : \"c47d46.fffe.20acae\",\n"
-            "  \"servo_state\" : \"SERVO_UNLOCKED\"\n"
+            "  \"gmIdentity\" : \"c47d46.fffe.20acae\"\n"
             "}"));
     free(ret);
 }

--- a/uctest/proc.c
+++ b/uctest/proc.c
@@ -1173,7 +1173,6 @@ Test(ProcTest, TIME_STATUS_NP)
     cr_expect(eq(int, r->fractional_nanoseconds, 0));
     cr_expect(eq(int, r->gmPresent, 0));
     cr_expect(zero(memcmp(r->gmIdentity.v, clockId, 8)));
-    cr_expect(eq(u8, r->servo_state, PTPMGMT_SERVO_UNLOCKED));
     m->free(m);
 }
 

--- a/utest/json2msg.cpp
+++ b/utest/json2msg.cpp
@@ -1840,8 +1840,7 @@ TEST(Json2msgTest, TIME_STATUS_NP)
             "\"nanoseconds_lsb\":0,"
             "\"fractional_nanoseconds\":0,"
             "\"gmPresent\":0,"
-            "\"gmIdentity\":\"c47d46.fffe.20acae\","
-            "\"servo_state\":\"SERVO_UNLOCKED\""
+            "\"gmIdentity\":\"c47d46.fffe.20acae\""
             "}}"));
     EXPECT_EQ(m.actionField(), SET);
     EXPECT_EQ(m.managementId(), TIME_STATUS_NP);
@@ -1860,7 +1859,6 @@ TEST(Json2msgTest, TIME_STATUS_NP)
     EXPECT_EQ(t->gmPresent, 0);
     ClockIdentity_t clockId = { 196, 125, 70, 255, 254, 32, 172, 174 };
     EXPECT_EQ(t->gmIdentity, clockId);
-    EXPECT_EQ(t->servo_state, SERVO_UNLOCKED);
 }
 
 // Tests GRANDMASTER_SETTINGS_NP managment ID

--- a/utest/msg2json.cpp
+++ b/utest/msg2json.cpp
@@ -1319,7 +1319,6 @@ TEST(Tlv2JsonTest, TIME_STATUS_NP)
     t.gmPresent = 0;
     ClockIdentity_t clockId = { 196, 125, 70, 255, 254, 32, 172, 174 };
     t.gmIdentity = clockId;
-    t.servo_state = SERVO_UNLOCKED;
     EXPECT_STREQ(tlv2json(TIME_STATUS_NP, &t).c_str(),
         "{\n"
         "  \"master_offset\" : 0,\n"
@@ -1331,8 +1330,7 @@ TEST(Tlv2JsonTest, TIME_STATUS_NP)
         "  \"nanoseconds_lsb\" : 0,\n"
         "  \"fractional_nanoseconds\" : 0,\n"
         "  \"gmPresent\" : 0,\n"
-        "  \"gmIdentity\" : \"c47d46.fffe.20acae\",\n"
-        "  \"servo_state\" : \"SERVO_UNLOCKED\"\n"
+        "  \"gmIdentity\" : \"c47d46.fffe.20acae\"\n"
         "}");
 }
 

--- a/utest/pmc_dump.cpp
+++ b/utest/pmc_dump.cpp
@@ -764,7 +764,6 @@ TEST(PmcDumpTest, TIME_STATUS_NP)
     t.gmPresent = 0;
     ClockIdentity_t clockId = { 196, 125, 70, 255, 254, 32, 172, 174 };
     t.gmIdentity = clockId;
-    t.servo_state = SERVO_UNLOCKED;
     useTestMode(true);
     call_dump(m, TIME_STATUS_NP, &t);
     EXPECT_STREQ(getPmcOut(),
@@ -775,8 +774,7 @@ TEST(PmcDumpTest, TIME_STATUS_NP)
         IDENT "gmTimeBaseIndicator        0"
         IDENT "lastGmPhaseChange          0x0000'0000000000000000.0000"
         IDENT "gmPresent                  false"
-        IDENT "gmIdentity                 c47d46.fffe.20acae"
-        IDENT "servo_state                SERVO_UNLOCKED");
+        IDENT "gmIdentity                 c47d46.fffe.20acae");
 }
 
 // Tests dump GRANDMASTER_SETTINGS_NP tlv

--- a/utest/proc.cpp
+++ b/utest/proc.cpp
@@ -907,7 +907,6 @@ TEST_F(ProcTest, TIME_STATUS_NP)
     EXPECT_EQ(r->fractional_nanoseconds, 0);
     EXPECT_EQ(r->gmPresent, 0);
     EXPECT_EQ(r->gmIdentity, clockId);
-    EXPECT_EQ(r->servo_state, SERVO_UNLOCKED);
 }
 
 // Tests GRANDMASTER_SETTINGS_NP structure


### PR DESCRIPTION
The previous implementation extracted the `servo_state` and used it to determine the `servo_locked` status. This has been refactored to directly use the `portState` to set `servo_locked`.