### PR TITLE
jclklib: Add disconnect function to Connect class

### DIFF
--- a/jclklib/proxy/connect_ptp4l.cpp
+++ b/jclklib/proxy/connect_ptp4l.cpp
@@ -357,9 +357,12 @@ int Connect::connect()
         ret = -errno;
 
     handle_connect(epd_event);
-    while (1) {
-        sleep(1);
-    }
 
     return 0;
+}
+
+void Connect::disconnect()
+{
+    obj.close();
+    sk->close();
 }

--- a/jclklib/proxy/connect_ptp4l.hpp
+++ b/jclklib/proxy/connect_ptp4l.hpp
@@ -22,5 +22,6 @@ namespace JClkLibProxy
     private:
     public:
         static int connect();
+        static void disconnect();
     };
 }

--- a/jclklib/proxy/main.cpp
+++ b/jclklib/proxy/main.cpp
@@ -26,7 +26,7 @@ using namespace std;
 
 int main()
 {
-    //BlockStopSignal();
+    BlockStopSignal();
     if(!ProxyTransport::init()) {
         cout << "Transport init failed" << endl;
         return -1;
@@ -38,6 +38,7 @@ int main()
     Connect::connect();
     WaitForStopSignal();
     PrintDebug("Got stop signal");
+    Connect::disconnect();
     if(!ProxyTransport::stop()) {
         cout << "stop failed" << endl;
         return -1;


### PR DESCRIPTION
- Implemented the disconnect function in the Connect class.
- The function closes the obj and sk objects to properly release resources.
- Ensures that connections are properly terminated when disconnect is called.

Jira: https://jira.devtools.intel.com/browse/IOTGREALTJ-251 