### PR TITLE
Add offset to synchronization state

### DIFF
--- a/jclklib/client/jclk_client_state.hpp
+++ b/jclklib/client/jclk_client_state.hpp
@@ -23,16 +23,17 @@
 #include <common/transport.hpp>
 #include <common/util.hpp>
 
-namespace JClkLibClient
-{
-struct jcl_state {
-    uint8_t  gm_identity[8];
-    bool     as_capable;
-    bool     offset_in_range;
-    bool     synced_to_primary_clock;
-    bool     gm_changed;
-    bool     composite_event;
-};
+namespace JClkLibClient {
+    struct jcl_state {
+        uint8_t  gm_identity[8];
+        bool     as_capable;
+        bool     offset_in_range;
+        bool     synced_to_primary_clock;
+        bool     gm_changed;
+        bool     composite_event;
+        int64_t  offset;
+        uint64_t timestamp;
+    };
 
 struct jcl_state_event_count {
     uint64_t offset_in_range_event_count;

--- a/jclklib/client/jclk_init.cpp
+++ b/jclklib/client/jclk_init.cpp
@@ -237,12 +237,15 @@ int JClkLibClientApi::jcl_status_wait(int timeout, jcl_state &jcl_state_ref,
         }
         /* Sleep for a short duration before the next iteration */
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    } while(std::chrono::high_resolution_clock::now() < end);
-    if(!event_changes_detected)
-        return false;
+    } while (std::chrono::high_resolution_clock::now() < end);
+
     /* Copy out the current state */
     eventCountRef = eventCount;
     jcl_state_ref = jcl_state;
+
+    if (!event_changes_detected)
+        return false;
+
     /* Reset the atomic count by reducing the corresponding eventCount */
     ClientSubscribeMessage::resetClientPtpEventStruct(
         appClientState.get_sessionId(),

--- a/jclklib/client/jclklib_client_api_c.cpp
+++ b/jclklib/client/jclklib_client_api_c.cpp
@@ -58,6 +58,9 @@ bool jcl_c_subscribe(jcl_c_client_ptr client_ptr,
     current_state->synced_to_primary_clock = state.synced_to_primary_clock;
     current_state->gm_changed = state.gm_changed;
     current_state->composite_event = state.composite_event;
+    current_state->offset = state.offset;
+    current_state->timestamp = state.timestamp;
+
     std::copy(std::begin(state.gm_identity), std::end(state.gm_identity),
         std::begin(current_state->gm_identity));
     return ret;
@@ -70,15 +73,21 @@ int jcl_c_status_wait(jcl_c_client_ptr client_ptr, int timeout,
     JClkLibClient::jcl_state_event_count eventCount = {};
     JClkLibClient::jcl_state state = {};
     int ret;
+
     ret = static_cast<JClkLibClient::JClkLibClientApi *>
         (client_ptr)->jcl_status_wait(timeout, state, eventCount);
-    if(ret <= 0)
+
+    if (ret < 0)
         return ret;
+
     current_state->as_capable = state.as_capable;
     current_state->offset_in_range = state.offset_in_range;
     current_state->synced_to_primary_clock = state.synced_to_primary_clock;
     current_state->gm_changed = state.gm_changed;
     current_state->composite_event = state.composite_event;
+    current_state->offset = state.offset;
+    current_state->timestamp = state.timestamp;
+
     std::copy(std::begin(state.gm_identity), std::end(state.gm_identity),
         std::begin(current_state->gm_identity));
     event_count->as_capable_event_count = eventCount.as_capable_event_count;

--- a/jclklib/client/jclklib_client_api_c.h
+++ b/jclklib/client/jclklib_client_api_c.h
@@ -50,6 +50,8 @@ struct jcl_c_state {
     bool    synced_to_primary_clock;
     bool    gm_changed;
     bool    composite_event;
+    int64_t offset;
+    int64_t timestamp;
 };
 
 struct jcl_c_event_count {

--- a/jclklib/client/notification_msg.cpp
+++ b/jclklib/client/notification_msg.cpp
@@ -199,28 +199,28 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
                 proxy_data.synced_to_primary_clock;
         if(composite_eventSub[0] & 1 << asCapableEvent)
             composite_client_ptp_data->composite_event &= proxy_data.as_capable;
-        if(composite_eventSub[0] &&
-            (old_composite_event != composite_client_ptp_data->composite_event))
-            client_ptp_data->composite_event_count.fetch_add(1,
-                std::memory_order_relaxed);
+
+        if (composite_eventSub[0] && (old_composite_event != composite_client_ptp_data->composite_event))
+            client_ptp_data->composite_event_count.fetch_add(1, std::memory_order_relaxed);
+
+        if (clock_gettime(CLOCK_REALTIME, &last_notification_time) == -1)
+            PrintDebug("ClientNotificationMessage::processMessage clock_gettime failed.\n");
+
         jclCurrentState.as_capable = client_ptp_data->as_capable;
         jclCurrentState.offset_in_range = client_ptp_data->master_offset_in_range;
-        jclCurrentState.synced_to_primary_clock =
-            client_ptp_data->synced_to_primary_clock;
-        jclCurrentState.composite_event =
-            composite_client_ptp_data->composite_event;
-        memcpy(jclCurrentState.gm_identity, client_ptp_data->gm_identity,
-            sizeof(client_ptp_data->gm_identity));
-        jclCurrentEventCount.offset_in_range_event_count =
-            client_ptp_data->offset_in_range_event_count;
-        jclCurrentEventCount.as_capable_event_count =
-            client_ptp_data->as_capable_event_count;
-        jclCurrentEventCount.synced_to_primary_clock_event_count =
-            client_ptp_data->synced_to_primary_clock_event_count;
-        jclCurrentEventCount.gm_changed_event_count =
-            client_ptp_data->gm_changed_event_count;
-        jclCurrentEventCount.composite_event_count =
-            client_ptp_data->composite_event_count;
+        jclCurrentState.synced_to_primary_clock = client_ptp_data->synced_to_primary_clock;
+        jclCurrentState.composite_event = composite_client_ptp_data->composite_event;
+        memcpy(jclCurrentState.gm_identity, client_ptp_data->gm_identity, sizeof(client_ptp_data->gm_identity));
+	jclCurrentState.offset = client_ptp_data->master_offset;
+	jclCurrentState.timestamp  = last_notification_time.tv_sec*NSEC_PER_SEC;
+	jclCurrentState.timestamp *= NSEC_PER_SEC;
+	jclCurrentState.timestamp += last_notification_time.tv_nsec;
+
+        jclCurrentEventCount.offset_in_range_event_count = client_ptp_data->offset_in_range_event_count;
+        jclCurrentEventCount.as_capable_event_count = client_ptp_data->as_capable_event_count;
+        jclCurrentEventCount.synced_to_primary_clock_event_count = client_ptp_data->synced_to_primary_clock_event_count;
+        jclCurrentEventCount.gm_changed_event_count = client_ptp_data->gm_changed_event_count;
+        jclCurrentEventCount.composite_event_count = client_ptp_data->composite_event_count;
     }
     return true;
 }

--- a/jclklib/common/msgq_tport.cpp
+++ b/jclklib/common/msgq_tport.cpp
@@ -32,9 +32,6 @@ using namespace std;
 #define QUEUE_FLAGS (O_RDONLY | O_CREAT)
 #define QUEUE_MODE  (S_IRUSR  | S_IWGRP)
 
-#define NSEC_PER_MSEC   (1000000 /*ns*/)
-#define NSEC_PER_SEC    (1000000000 /*ns*/)
-
 DECLARE_STATIC(MessageQueue::mqProxyName, MESSAGE_QUEUE_PREFIX);
 DECLARE_STATIC(MessageQueue::mqListenerDesc,
     Transport::InvalidTransportWorkDesc);

--- a/jclklib/common/util.hpp
+++ b/jclklib/common/util.hpp
@@ -18,6 +18,11 @@
 #ifndef UTIL_HPP
 #define UTIL_HPP
 
+// Some commonly used constants
+//
+#define NSEC_PER_MSEC	(1000000 /*ns*/)
+#define NSEC_PER_SEC	(1000000000 /*ns*/)
+
 #define UNIQUE_TYPEOF(x) remove_reference<decltype(*(x).get())>::type
 #define FUTURE_TYPEOF(x) decltype((x).get())
 #define DECLARE_STATIC(x,...) decltype(x) x __VA_OPT__({) __VA_ARGS__ __VA_OPT__(})

--- a/jclklib/proxy/msgq_tport.cpp
+++ b/jclklib/proxy/msgq_tport.cpp
@@ -30,9 +30,6 @@ using namespace JClkLibCommon;
 using namespace JClkLibProxy;
 using namespace std;
 
-#define NSEC_PER_MSEC   (1000000 /*ns*/)
-#define NSEC_PER_SEC    (1000000000 /*ns*/)
-
 LISTENER_CONTEXT_PROCESS_MESSAGE_TYPE(
     ProxyMessageQueueListenerContext::processMessage)
 {


### PR DESCRIPTION
It would be useful for the user to be able to get the GM offset from ptp4l to determine how well synchronized we are to the GM

- Add offset from GM to state
- Change code to update state even if no event occurs
- Move some constants into util.h