### PR TITLE
Add offset to state, initial

### DIFF
--- a/jclklib/client/jclk_init.cpp
+++ b/jclklib/client/jclk_init.cpp
@@ -238,11 +238,11 @@ int JClkLibClientApi::jcl_status_wait(int timeout, jcl_state &jcl_state_ref,
         /* Sleep for a short duration before the next iteration */
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     } while(std::chrono::high_resolution_clock::now() < end);
-    if(!event_changes_detected)
-        return false;
     /* Copy out the current state */
     eventCountRef = eventCount;
     jcl_state_ref = jcl_state;
+    if(!event_changes_detected)
+        return false;
     /* Reset the atomic count by reducing the corresponding eventCount */
     ClientSubscribeMessage::resetClientPtpEventStruct(
         appClientState.get_sessionId(),

--- a/jclklib/client/jclklib_client_api_c.cpp
+++ b/jclklib/client/jclklib_client_api_c.cpp
@@ -58,6 +58,8 @@ bool jcl_c_subscribe(jcl_c_client_ptr client_ptr,
     current_state->synced_to_primary_clock = state.synced_to_primary_clock;
     current_state->gm_changed = state.gm_changed;
     current_state->composite_event = state.composite_event;
+    current_state->clock_offset = state.clock_offset;
+    current_state->notification_timestamp = state.notification_timestamp;
     std::copy(std::begin(state.gm_identity), std::end(state.gm_identity),
         std::begin(current_state->gm_identity));
     return ret;
@@ -79,6 +81,8 @@ int jcl_c_status_wait(jcl_c_client_ptr client_ptr, int timeout,
     current_state->synced_to_primary_clock = state.synced_to_primary_clock;
     current_state->gm_changed = state.gm_changed;
     current_state->composite_event = state.composite_event;
+    current_state->clock_offset = state.clock_offset;
+    current_state->notification_timestamp = state.notification_timestamp;
     std::copy(std::begin(state.gm_identity), std::end(state.gm_identity),
         std::begin(current_state->gm_identity));
     event_count->as_capable_event_count = eventCount.as_capable_event_count;

--- a/jclklib/client/notification_msg.cpp
+++ b/jclklib/client/notification_msg.cpp
@@ -108,12 +108,14 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
         std::uint32_t eventSub[1];
         std::uint32_t composite_eventSub[1];
         ClientState *currentClientState = *it;
-        struct timespec last_notification_time;
+        struct timespec last_notification_time = {};
         if(clock_gettime(CLOCK_MONOTONIC, &last_notification_time) == -1)
             PrintDebug("ClientNotificationMessage::processMessage \
                 clock_gettime failed.\n");
         else
             currentClientState->set_last_notification_time(last_notification_time);
+        double seconds = last_notification_time.tv_sec;
+        double nanoseconds = last_notification_time.tv_nsec / 1e9;
         jcl_state &jclCurrentState =
             currentClientState->get_eventState();
         jcl_state_event_count &jclCurrentEventCount =
@@ -205,6 +207,8 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
                 std::memory_order_relaxed);
         jclCurrentState.as_capable = client_ptp_data->as_capable;
         jclCurrentState.offset_in_range = client_ptp_data->master_offset_in_range;
+        jclCurrentState.clock_offset = client_ptp_data->master_offset;
+        jclCurrentState.notification_timestamp = seconds + nanoseconds;
         jclCurrentState.synced_to_primary_clock =
             client_ptp_data->synced_to_primary_clock;
         jclCurrentState.composite_event =

--- a/jclklib/common/msgq_tport.cpp
+++ b/jclklib/common/msgq_tport.cpp
@@ -32,9 +32,6 @@ using namespace std;
 #define QUEUE_FLAGS (O_RDONLY | O_CREAT)
 #define QUEUE_MODE  (S_IRUSR  | S_IWGRP)
 
-#define NSEC_PER_MSEC   (1000000 /*ns*/)
-#define NSEC_PER_SEC    (1000000000 /*ns*/)
-
 DECLARE_STATIC(MessageQueue::mqProxyName, MESSAGE_QUEUE_PREFIX);
 DECLARE_STATIC(MessageQueue::mqListenerDesc,
     Transport::InvalidTransportWorkDesc);

--- a/jclklib/common/util.hpp
+++ b/jclklib/common/util.hpp
@@ -18,6 +18,10 @@
 #ifndef UTIL_HPP
 #define UTIL_HPP
 
+/* Some commonly used constants */
+#define NSEC_PER_MSEC   (1000000)
+#define NSEC_PER_SEC    (1000000000)
+
 #define UNIQUE_TYPEOF(x) remove_reference<decltype(*(x).get())>::type
 #define FUTURE_TYPEOF(x) decltype((x).get())
 #define DECLARE_STATIC(x,...) decltype(x) x __VA_OPT__({) __VA_ARGS__ __VA_OPT__(})

--- a/jclklib/proxy/msgq_tport.cpp
+++ b/jclklib/proxy/msgq_tport.cpp
@@ -30,9 +30,6 @@ using namespace JClkLibCommon;
 using namespace JClkLibProxy;
 using namespace std;
 
-#define NSEC_PER_MSEC   (1000000 /*ns*/)
-#define NSEC_PER_SEC    (1000000000 /*ns*/)
-
 LISTENER_CONTEXT_PROCESS_MESSAGE_TYPE(
     ProxyMessageQueueListenerContext::processMessage)
 {

--- a/jclklib/sample/jclk_c_test.c
+++ b/jclklib/sample/jclk_c_test.c
@@ -178,6 +178,10 @@ int main(int argc, char *argv[])
             state.gm_identity[2], state.gm_identity[3],
             state.gm_identity[4], state.gm_identity[5],
             state.gm_identity[6], state.gm_identity[7]);
+        printf("| %-25s | %-15ld ns |\n",
+                "clock_offset", state.clock_offset);
+        printf("| %-25s | %-16f s |\n",
+                "notification_timestamp", state.notification_timestamp);
     }
     printf("+---------------------------+--------------------+\n");
     if (subscription.composite_event[0]) {
@@ -248,6 +252,10 @@ int main(int argc, char *argv[])
                 state.gm_identity[2], state.gm_identity[3],
                 state.gm_identity[4], state.gm_identity[5],
                 state.gm_identity[6], state.gm_identity[7]);
+            printf("| %-25s |     %-19ld ns |\n",
+                "clock_offset", state.clock_offset);
+            printf("| %-25s |     %-20f s |\n",
+                "notification_timestamp", state.notification_timestamp);
         }
         printf("+---------------------------+--------------+-------------+\n");
         if (subscription.composite_event[0]) {

--- a/jclklib/sample/jclk_test.cpp
+++ b/jclklib/sample/jclk_test.cpp
@@ -203,6 +203,10 @@ int main(int argc, char *argv[])
             state.gm_identity[2], state.gm_identity[3],
             state.gm_identity[4], state.gm_identity[5],
             state.gm_identity[6], state.gm_identity[7]);
+        printf("| %-25s | %-15ld ns |\n",
+                "clock_offset", state.clock_offset);
+        printf("| %-25s | %-16f s |\n",
+                "notification_timestamp", state.notification_timestamp);
     }
     printf("+---------------------------+--------------------+\n");
     if (composite_event[0]) {
@@ -273,6 +277,10 @@ int main(int argc, char *argv[])
                 state.gm_identity[2], state.gm_identity[3],
                 state.gm_identity[4], state.gm_identity[5],
                 state.gm_identity[6], state.gm_identity[7]);
+            printf("| %-25s |     %-19ld ns |\n",
+                "clock_offset", state.clock_offset);
+            printf("| %-25s |     %-20f s |\n",
+                "notification_timestamp", state.notification_timestamp);
         }
         printf("+---------------------------+--------------+-------------+\n");
         if (composite_event[0]) {

--- a/pub/c/jclklib_client_api_c.h
+++ b/pub/c/jclklib_client_api_c.h
@@ -54,6 +54,8 @@ struct jcl_c_state {
     bool synced_to_primary_clock;         /**< Synced to primary clock */
     bool gm_changed;                      /**< Primary clock UUID changed */
     bool composite_event;                 /**< Composite event */
+    int64_t  clock_offset;                /**< Clock offset */
+    double notification_timestamp;        /**< Timestamp for last notification */
 };
 
 /** Event count for the events */

--- a/pub/jclk_client_state.hpp
+++ b/pub/jclk_client_state.hpp
@@ -34,6 +34,8 @@ struct jcl_state {
     bool     synced_to_primary_clock; /**< Synced to primary clock */
     bool     gm_changed; /**< Primary clock UUID changed */
     bool     composite_event; /**< Composite event */
+    int64_t  clock_offset; /**< Clock offset */
+    double   notification_timestamp; /**< Timestamp for last notification */
 };
 
 /**


### PR DESCRIPTION
It would be useful for the user to be able to get the GM offset from ptp4l to determine how well synchronized we are to the GM

Add offset from GM to state
Change code to update state even if no event occurs
Move some constants into util.h

Sample apps output:
![image](https://github.com/user-attachments/assets/2d65a5a6-7588-4142-8f2d-3f19910468a6)
