### PR TITLE
clkmgr: Change notification timestamp type and update state when using the C api

### DIFF
--- a/clkmgr/client/clkmgr_client_api_c.cpp
+++ b/clkmgr/client/clkmgr_client_api_c.cpp
@@ -74,7 +74,7 @@ int clkmgr_c_status_wait(clkmgr_c_client_ptr client_ptr, int timeout,
     int ret;
     ret = static_cast<clkmgr::ClkmgrClientApi *>
         (client_ptr)->clkmgr_status_wait(timeout, state, eventCount);
-    if(ret <= 0)
+    if(ret < 0)
         return ret;
     current_state->as_capable = state.as_capable;
     current_state->offset_in_range = state.offset_in_range;
@@ -85,6 +85,8 @@ int clkmgr_c_status_wait(clkmgr_c_client_ptr client_ptr, int timeout,
     current_state->notification_timestamp = state.notification_timestamp;
     std::copy(std::begin(state.gm_identity), std::end(state.gm_identity),
         std::begin(current_state->gm_identity));
+    if(ret == 0)
+        return ret;
     event_count->as_capable_event_count = eventCount.as_capable_event_count;
     event_count->composite_event_count = eventCount.composite_event_count;
     event_count->gm_changed_event_count = eventCount.gm_changed_event_count;

--- a/clkmgr/client/notification_msg.cpp
+++ b/clkmgr/client/notification_msg.cpp
@@ -114,8 +114,6 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
                 clock_gettime failed.\n");
         else
             currentClientState->set_last_notification_time(last_notification_time);
-        double seconds = last_notification_time.tv_sec;
-        double nanoseconds = last_notification_time.tv_nsec / 1e9;
         clkmgr_state &clkmgrCurrentState =
             currentClientState->get_eventState();
         clkmgr_state_event_count &clkmgrCurrentEventCount =
@@ -209,7 +207,9 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
         clkmgrCurrentState.offset_in_range =
             client_ptp_data->master_offset_in_range;
         clkmgrCurrentState.clock_offset = client_ptp_data->master_offset;
-        clkmgrCurrentState.notification_timestamp = seconds + nanoseconds;
+        clkmgrCurrentState.notification_timestamp = last_notification_time.tv_sec;
+        clkmgrCurrentState.notification_timestamp *= NSEC_PER_SEC;
+        clkmgrCurrentState.notification_timestamp += last_notification_time.tv_nsec;
         clkmgrCurrentState.synced_to_primary_clock =
             client_ptp_data->synced_to_primary_clock;
         clkmgrCurrentState.composite_event =

--- a/clkmgr/client/subscribe_msg.cpp
+++ b/clkmgr/client/subscribe_msg.cpp
@@ -65,8 +65,6 @@ PARSE_RXBUFFER_TYPE(ClientSubscribeMessage::parseBuffer)
             clock_gettime failed.\n");
     else
         currentClientState->set_last_notification_time(last_notification_time);
-    double seconds = last_notification_time.tv_sec;
-    double nanoseconds = last_notification_time.tv_nsec / 1e9;
     currentClientState->get_eventSub().get_event().readEvent(eventSub,
         (std::size_t)sizeof(eventSub));
     std::uint32_t composite_eventSub[1];
@@ -144,7 +142,9 @@ PARSE_RXBUFFER_TYPE(ClientSubscribeMessage::parseBuffer)
         client_data->synced_to_primary_clock;
     clkmgrCurrentState->composite_event = composite_client_data->composite_event;
     clkmgrCurrentState->clock_offset = client_data->master_offset;
-    clkmgrCurrentState->notification_timestamp = seconds + nanoseconds;
+    clkmgrCurrentState->notification_timestamp = last_notification_time.tv_sec;
+    clkmgrCurrentState->notification_timestamp *= NSEC_PER_SEC;
+    clkmgrCurrentState->notification_timestamp += last_notification_time.tv_nsec;
     memcpy(clkmgrCurrentState->gm_identity, client_data->gm_identity,
         sizeof(client_data->gm_identity));
     return true;

--- a/pub/c/clkmgr_client_api_c.h
+++ b/pub/c/clkmgr_client_api_c.h
@@ -55,7 +55,7 @@ struct clkmgr_c_state {
     bool gm_changed;                      /**< Primary clock UUID changed */
     bool composite_event;                 /**< Composite event */
     int64_t  clock_offset;                /**< Clock offset */
-    double notification_timestamp;        /**< Timestamp for last notification */
+    uint64_t notification_timestamp;      /**< Timestamp for last notification */
 };
 
 /** Event count for the events */

--- a/pub/clkmgr_client_state.hpp
+++ b/pub/clkmgr_client_state.hpp
@@ -35,7 +35,7 @@ struct clkmgr_state {
     bool     gm_changed; /**< Primary clock UUID changed */
     bool     composite_event; /**< Composite event */
     int64_t  clock_offset; /**< Clock offset */
-    double   notification_timestamp; /**< Timestamp for last notification */
+    uint64_t   notification_timestamp; /**< Timestamp for last notification */
 };
 
 /**


### PR DESCRIPTION
clkmgr: Change notification timestamp type to uint64_t representing nanoseconds since the epoch.

clkmgr: When using the C API, update client state after wait whether or not an event occurs