### PR TITLE
clkmgr/client: Change to CLOCK_REALTIME for update timestamp

### DIFF
--- a/clkmgr/client/notification_msg.cpp
+++ b/clkmgr/client/notification_msg.cpp
@@ -109,7 +109,7 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
         std::uint32_t composite_eventSub;
         ClientState *currentClientState = *it;
         struct timespec last_notification_time = {};
-        if(clock_gettime(CLOCK_MONOTONIC, &last_notification_time) == -1)
+        if(clock_gettime(CLOCK_REALTIME, &last_notification_time) == -1)
             PrintDebug("ClientNotificationMessage::processMessage \
                 clock_gettime failed.\n");
         else


### PR DESCRIPTION
The update timestamp currently use CLOCK_MONOTONIC. This cannot be used to correlate events on multiple devices. An example use case, is using Grafana to show how well devices in a cluster are synchronized. CLOCK_REALTIME is synced and can be used to correlate events across multiple devices.