### PR TITLE
clkmgr: Change to CLOCK_REALTIME for update timestamp

### DIFF
--- a/clkmgr/TEST_clkmgr.md
+++ b/clkmgr/TEST_clkmgr.md
@@ -110,17 +110,17 @@ reference.
     ```
 3. Run the sample application on DUT:
 
-3a. c++ sample application:
-    ```bash
-    cd libptpmgmt_iaclocklib/clkmgr/client
-    sudo ./run_clkmgr_test.sh <optional arguments>
+    a. c++ sample application:
+        ```bash
+        cd libptpmgmt_iaclocklib/clkmgr/client
+        sudo ./run_clkmgr_test.sh <optional arguments>
+        ```
 
-    ```
-3b. c sample application:
-    ```bash
-    cd libptpmgmt_iaclocklib/clkmgr/client
-    sudo ./run_clkmgr_c_test.sh <optional arguments>
-    ```
+    b. c sample application:
+        ```bash
+        cd libptpmgmt_iaclocklib/clkmgr/client
+        sudo ./run_clkmgr_c_test.sh <optional arguments>
+        ```
 
 # Examples of result :
 
@@ -161,99 +161,51 @@ Options:
 
 Example output of c++ sample application (clkmgr_test) :
 ```bash
-~/libptpmgmt_iaclocklib/clkmgr/sample# ./run_clkmgr_test.sh -l -100 -u 100 -t 0
+~/libptpmgmt_iaclocklib/clkmgr/sample# ./run_clkmgr_test.sh -l -10 -u 10
 [clkmgr] Connected. Session ID : 0
 [clkmgr] set subscribe event : 0xf
 [clkmgr] set composite event : 0x7
-GM Offset upper limit: 100 ns
-GM Offset lower limit: -100 ns
+GM Offset upper limit: 10 ns
+GM Offset lower limit: -10 ns
 
-[clkmgr][22569.983] Obtained data from Subscription Event:
-+---------------------------+--------------------+
-| Event                     | Event Status       |
-+---------------------------+--------------------+
-| offset_in_range           | 0                  |
-| synced_to_primary_clock   | 0                  |
-| as_capable                | 0                  |
-| gm_Changed                | 0                  |
-+---------------------------+--------------------+
-| UUID                      | 000000.0000.000000 |
-| clock_offset              | 0               ns |
-| notification_timestamp    | 22569.982        s |
-+---------------------------+--------------------+
-| composite_event           | 0                  |
-| - offset_in_range         |                    |
-| - synced_to_primary_clock |                    |
-| - as_capable              |                    |
-+---------------------------+--------------------+
+[clkmgr][174.381] Obtained data from Subscription Event:
++---------------------------+------------------------+
+| Event                     | Event Status           |
++---------------------------+------------------------+
+| offset_in_range           | 1                      |
+| synced_to_primary_clock   | 1                      |
+| as_capable                | 1                      |
+| gm_Changed                | 1                      |
++---------------------------+------------------------+
+| UUID                      | 22abbc.fffe.bb1234     |
+| clock_offset              | -2                  ns |
+| notification_timestamp    | 1726024045215150041 ns |
++---------------------------+------------------------+
+| composite_event           | 1                      |
+| - offset_in_range         |                        |
+| - synced_to_primary_clock |                        |
+| - as_capable              |                        |
++---------------------------+------------------------+
 
-[...]
-
-[clkmgr][22582.071] Waiting for Notification Event...
-[clkmgr][22582.071] Obtained data from Notification Event:
+[clkmgr][175.381] Waiting for Notification Event...
+[clkmgr][177.045] Obtained data from Notification Event:
 +---------------------------+--------------+-------------+
 | Event                     | Event Status | Event Count |
 +---------------------------+--------------+-------------+
-| offset_in_range           | 1            | 1           |
+| offset_in_range           | 0            | 1           |
 | synced_to_primary_clock   | 1            | 0           |
 | as_capable                | 1            | 0           |
 | gm_Changed                | 0            | 0           |
 +---------------------------+--------------+-------------+
-| UUID                      |     00a0c9.fffe.000000     |
-| clock_offset              |     -90                 ns |
-| notification_timestamp    |     22582.068            s |
+| UUID                      |     22abbc.fffe.bb1234     |
+| clock_offset              |     11                  ns |
+| notification_timestamp    |     1726024047876554406 ns |
 +---------------------------+--------------+-------------+
-| composite_event           | 1            | 1           |
+| composite_event           | 0            | 1           |
 | - offset_in_range         |              |             |
 | - synced_to_primary_clock |              |             |
 | - as_capable              |              |             |
 +---------------------------+--------------+-------------+
-
-```
-
-Example output of c sample application (clkmgr_c_test) :
-```bash
-~/libptpmgmt_iaclocklib/clkmgr/sample# ./run_clkmgr_c_test.sh -l -100 -u 100 -t 0
-[clkmgr][20271.775] Obtained data from Subscription Event:
-+---------------------------+--------------------+
-| Event                     | Event Status       |
-+---------------------------+--------------------+
-| offset_in_range           | 0                  |
-| synced_to_primary_clock   | 0                  |
-| as_capable                | 0                  |
-| gm_Changed                | 0                  |
-+---------------------------+--------------------+
-| UUID                      | 000000.0000.000000 |
-| clock_offset              | 0               ns |
-| notification_timestamp    | 20271.774        s |
-+---------------------------+--------------------+
-| composite_event           | 0                  |
-| - offset_in_range         |                    |
-| - synced_to_primary_clock |                    |
-| - as_capable              |                    |
-+---------------------------+--------------------+
-
-[...]
-
-[clkmgr][20325.321] Obtained data from Notification Event:
-+---------------------------+--------------+-------------+
-| Event                     | Event Status | Event Count |
-+---------------------------+--------------+-------------+
-| offset_in_range           | 1            | 1           |
-| synced_to_primary_clock   | 1            | 0           |
-| as_capable                | 1            | 0           |
-| gm_Changed                | 0            | 0           |
-+---------------------------+--------------+-------------+
-| UUID                      |     00a0c9.fffe.000000     |
-| clock_offset              |     -81                 ns |
-| notification_timestamp    |     20325.318            s |
-+---------------------------+--------------+-------------+
-| composite_event           | 1            | 1           |
-| - offset_in_range         |              |             |
-| - synced_to_primary_clock |              |             |
-| - as_capable              |              |             |
-+---------------------------+--------------+-------------+
-
 ```
 
 Note :

--- a/clkmgr/client/clockmanager.cpp
+++ b/clkmgr/client/clockmanager.cpp
@@ -158,7 +158,7 @@ int64_t timespec_delta(const timespec &last_notification_time,
 bool check_proxy_liveness(ClientState &appClientState)
 {
     struct timespec current_time;
-    if(clock_gettime(CLOCK_MONOTONIC, &current_time) == -1)
+    if(clock_gettime(CLOCK_REALTIME, &current_time) == -1)
         PrintDebug("[CONNECT] Failed to get current time.\n");
     else {
         int64_t timeout =

--- a/clkmgr/client/notification_msg.cpp
+++ b/clkmgr/client/notification_msg.cpp
@@ -109,7 +109,7 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
         std::uint32_t composite_eventSub;
         ClientState *currentClientState = *it;
         struct timespec last_notification_time = {};
-        if(clock_gettime(CLOCK_MONOTONIC, &last_notification_time) == -1)
+        if(clock_gettime(CLOCK_REALTIME, &last_notification_time) == -1)
             PrintDebug("ClientNotificationMessage::processMessage \
                 clock_gettime failed.\n");
         else

--- a/clkmgr/client/subscribe_msg.cpp
+++ b/clkmgr/client/subscribe_msg.cpp
@@ -60,7 +60,7 @@ PARSE_RXBUFFER_TYPE(ClientSubscribeMessage::parseBuffer)
     ptp_event data = {};
     std::uint32_t eventSub;
     struct timespec last_notification_time = {};
-    if(clock_gettime(CLOCK_MONOTONIC, &last_notification_time) == -1)
+    if(clock_gettime(CLOCK_REALTIME, &last_notification_time) == -1)
         PrintDebug("ClientNotificationMessage::processMessage \
             clock_gettime failed.\n");
     else

--- a/clkmgr/sample/clkmgr_c_test.c
+++ b/clkmgr/sample/clkmgr_c_test.c
@@ -159,50 +159,50 @@ int main(int argc, char *argv[])
 
     printf("[clkmgr][%.3f] Obtained data from Subscription Event:\n",
         getMonotonicTime());
-    printf("+---------------------------+--------------------+\n");
-    printf("| %-25s | %-18s |\n", "Event", "Event Status");
+    printf("+---------------------------+------------------------+\n");
+    printf("| %-25s | %-22s |\n", "Event", "Event Status");
     if (subscription.event_mask) {
-        printf("+---------------------------+--------------------+\n");
+        printf("+---------------------------+------------------------+\n");
     }
     if (subscription.event_mask & clkmgr_c_event_gm_offset) {
-        printf("| %-25s | %-18d |\n", "offset_in_range",
+        printf("| %-25s | %-22d |\n", "offset_in_range",
             event_state.offset_in_range);
     }
     if (subscription.event_mask & clkmgr_c_event_synced2gm) {
-        printf("| %-25s | %-18d |\n", "synced_to_primary_clock", event_state.synced_to_primary_clock);
+        printf("| %-25s | %-22d |\n", "synced_to_primary_clock", event_state.synced_to_primary_clock);
     }
     if (subscription.event_mask & clkmgr_c_event_as_capable) {
-        printf("| %-25s | %-18d |\n", "as_capable", event_state.as_capable);
+        printf("| %-25s | %-22d |\n", "as_capable", event_state.as_capable);
     }
     if (subscription.event_mask & clkmgr_c_event_gm_changed) {
-        printf("| %-25s | %-18d |\n", "gm_Changed", event_state.gm_changed);
+        printf("| %-25s | %-22d |\n", "gm_Changed", event_state.gm_changed);
     }
-    printf("+---------------------------+--------------------+\n");
-    printf("| %-25s | %02x%02x%02x.%02x%02x.%02x%02x%02x |\n", "UUID",
+    printf("+---------------------------+------------------------+\n");
+    printf("| %-25s | %02x%02x%02x.%02x%02x.%02x%02x%02x     |\n", "UUID",
         event_state.gm_identity[0], event_state.gm_identity[1],
         event_state.gm_identity[2], event_state.gm_identity[3],
         event_state.gm_identity[4], event_state.gm_identity[5],
         event_state.gm_identity[6], event_state.gm_identity[7]);
-    printf("| %-25s | %-15ld ns |\n",
+    printf("| %-25s | %-19ld ns |\n",
             "clock_offset", event_state.clock_offset);
-    printf("| %-25s | %-16.3f s |\n",
-            "notification_timestamp", event_state.notification_timestamp / 1e9);
-    printf("+---------------------------+--------------------+\n");
+    printf("| %-25s | %-19ld ns |\n",
+            "notification_timestamp", event_state.notification_timestamp);
+    printf("+---------------------------+------------------------+\n");
     if (subscription.composite_event_mask) {
-        printf("| %-25s | %-18d |\n", "composite_event",
+        printf("| %-25s | %-22d |\n", "composite_event",
             event_state.composite_event);
     }
     if (subscription.composite_event_mask & clkmgr_c_event_gm_offset) {
-        printf("| - %-23s | %-18s |\n", "offset_in_range", " ");
+        printf("| - %-23s | %-22s |\n", "offset_in_range", " ");
     }
     if (subscription.composite_event_mask & clkmgr_c_event_synced2gm) {
-        printf("| - %-19s | %-18s |\n", "synced_to_primary_clock", " ");
+        printf("| - %-19s | %-22s |\n", "synced_to_primary_clock", " ");
     }
     if (subscription.composite_event_mask & clkmgr_c_event_as_capable) {
-        printf("| - %-23s | %-18s |\n", "as_capable", " ");
+        printf("| - %-23s | %-22s |\n", "as_capable", " ");
     }
     if (subscription.composite_event_mask) {
-        printf("+---------------------------+--------------------+\n\n");
+        printf("+---------------------------+------------------------+\n\n");
     } else {
         printf("\n");
     }
@@ -259,8 +259,8 @@ int main(int argc, char *argv[])
             event_state.gm_identity[6], event_state.gm_identity[7]);
         printf("| %-25s |     %-19ld ns |\n",
             "clock_offset", event_state.clock_offset);
-        printf("| %-25s |     %-20.3f s |\n",
-            "notification_timestamp", event_state.notification_timestamp / 1e9);
+        printf("| %-25s |     %-19ld ns |\n",
+            "notification_timestamp", event_state.notification_timestamp);
         printf("+---------------------------+--------------+-------------+\n");
         if (subscription.composite_event_mask) {
             printf("| %-25s | %-12d | %-11d |\n", "composite_event",

--- a/clkmgr/sample/clkmgr_test.cpp
+++ b/clkmgr/sample/clkmgr_test.cpp
@@ -178,50 +178,50 @@ int main(int argc, char *argv[])
 
     printf("[clkmgr][%.3f] Obtained data from Subscription Event:\n",
         getMonotonicTime());
-    printf("+---------------------------+--------------------+\n");
-    printf("| %-25s | %-18s |\n", "Event", "Event Status");
+    printf("+---------------------------+------------------------+\n");
+    printf("| %-25s | %-22s |\n", "Event", "Event Status");
     if (event2Sub) {
-        printf("+---------------------------+--------------------+\n");
+        printf("+---------------------------+------------------------+\n");
     }
     if (event2Sub & eventGMOffset) {
-        printf("| %-25s | %-18d |\n", "offset_in_range",
+        printf("| %-25s | %-22d |\n", "offset_in_range",
             eventState.offset_in_range);
     }
     if (event2Sub & eventSyncedToGM) {
-        printf("| %-25s | %-18d |\n", "synced_to_primary_clock", eventState.synced_to_primary_clock);
+        printf("| %-25s | %-22d |\n", "synced_to_primary_clock", eventState.synced_to_primary_clock);
     }
     if (event2Sub & eventASCapable) {
-        printf("| %-25s | %-18d |\n", "as_capable", eventState.as_capable);
+        printf("| %-25s | %-22d |\n", "as_capable", eventState.as_capable);
     }
     if (event2Sub & eventGMChanged) {
-        printf("| %-25s | %-18d |\n", "gm_Changed", eventState.gm_changed);
+        printf("| %-25s | %-22d |\n", "gm_Changed", eventState.gm_changed);
     }
-    printf("+---------------------------+--------------------+\n");
-    printf("| %-25s | %02x%02x%02x.%02x%02x.%02x%02x%02x |\n", "UUID",
+    printf("+---------------------------+------------------------+\n");
+    printf("| %-25s | %02x%02x%02x.%02x%02x.%02x%02x%02x     |\n", "UUID",
         eventState.gm_identity[0], eventState.gm_identity[1],
         eventState.gm_identity[2], eventState.gm_identity[3],
         eventState.gm_identity[4], eventState.gm_identity[5],
         eventState.gm_identity[6], eventState.gm_identity[7]);
-    printf("| %-25s | %-15ld ns |\n",
+    printf("| %-25s | %-19ld ns |\n",
             "clock_offset", eventState.clock_offset);
-    printf("| %-25s | %-16.3f s |\n",
-            "notification_timestamp", eventState.notification_timestamp / 1e9);
-    printf("+---------------------------+--------------------+\n");
+    printf("| %-25s | %-19ld ns |\n",
+            "notification_timestamp", eventState.notification_timestamp);
+    printf("+---------------------------+------------------------+\n");
     if (composite_event) {
-        printf("| %-25s | %-18d |\n", "composite_event",
+        printf("| %-25s | %-22d |\n", "composite_event",
             eventState.composite_event);
     }
     if (composite_event & eventGMOffset) {
-        printf("| - %-23s | %-18s |\n", "offset_in_range", " ");
+        printf("| - %-23s | %-22s |\n", "offset_in_range", " ");
     }
     if (composite_event & eventSyncedToGM) {
-        printf("| - %-19s | %-18s |\n", "synced_to_primary_clock", " ");
+        printf("| - %-19s | %-22s |\n", "synced_to_primary_clock", " ");
     }
     if (composite_event & eventASCapable) {
-        printf("| - %-23s | %-18s |\n", "as_capable", " ");
+        printf("| - %-23s | %-22s |\n", "as_capable", " ");
     }
     if (composite_event) {
-        printf("+---------------------------+--------------------+\n\n");
+        printf("+---------------------------+------------------------+\n\n");
     } else {
         printf("\n");
     }
@@ -278,8 +278,8 @@ int main(int argc, char *argv[])
             eventState.gm_identity[6], eventState.gm_identity[7]);
         printf("| %-25s |     %-19ld ns |\n",
             "clock_offset", eventState.clock_offset);
-        printf("| %-25s |     %-20.3f s |\n",
-            "notification_timestamp", eventState.notification_timestamp / 1e9);
+        printf("| %-25s |     %-19ld ns |\n",
+            "notification_timestamp", eventState.notification_timestamp);
         printf("+---------------------------+--------------+-------------+\n");
         if (composite_event) {
             printf("| %-25s | %-12d | %-11d |\n", "composite_event",


### PR DESCRIPTION
The update timestamp currently use CLOCK_MONOTONIC. This cannot be used to correlate events on multiple devices. An example use case, is using Grafana to show how well devices in a cluster are synchronized. CLOCK_REALTIME is synced and can be used to correlate events across multiple devices.