### PR TITLE
clkmgr: Refactor event handling and add support for GM identity.

### DIFF
--- a/clkmgr/common/message.hpp
+++ b/clkmgr/common/message.hpp
@@ -75,9 +75,23 @@ class Message
     virtual std::string toString();
 
     virtual ~Message() = default;
-    DECLARE_ACCESSOR(msgId);
-    DECLARE_ACCESSOR(msgAck);
-    DECLARE_ACCESSOR(sessionId);
+
+    const decltype(msgId) &getc_msgId() { return msgId; }
+    decltype(msgId) &get_msgId() { return msgId; }
+    void set_msgId(const decltype(msgId) &msgId) { this->msgId = msgId; }
+    decltype(msgId) c_get_val_msgId() const { return msgId; }
+
+    const decltype(msgAck) &getc_msgAck() { return msgAck; }
+    decltype(msgAck) &get_msgAck() { return msgAck; }
+    void set_msgAck(const decltype(msgAck) &msgAck) { this->msgAck = msgAck; }
+    decltype(msgAck) c_get_val_msgAck() const { return msgAck; }
+
+    const decltype(sessionId) &getc_sessionId() { return sessionId; }
+    decltype(sessionId) &get_sessionId() { return sessionId; }
+    void set_sessionId(const decltype(sessionId) &sessionId) {
+        this->sessionId = sessionId;
+    }
+    decltype(sessionId) c_get_val_sessionId() const { return sessionId; }
 
     static bool initMessage() { return false; };
     static bool init() { return false; }

--- a/clkmgr/common/transport.hpp
+++ b/clkmgr/common/transport.hpp
@@ -40,8 +40,17 @@ class TransportContext
     bool init() { return _init; }
     TransportContext() : _init(true), offset(0) {}
     virtual ~TransportContext() = default;
-    DECLARE_ACCESSOR(offset);
-    DECLARE_ACCESSOR(buffer);
+
+    const decltype(offset) &getc_offset() { return offset; }
+    decltype(offset) &get_offset() { return offset; }
+    void set_offset(const decltype(offset) &offset) { this->offset = offset; }
+    decltype(offset) c_get_val_offset() const { return offset; }
+
+    const decltype(buffer) &getc_buffer() { return buffer; }
+    decltype(buffer) &get_buffer() { return buffer; }
+    void set_buffer(const decltype(buffer) &buffer) { this->buffer = buffer; }
+    decltype(buffer) c_get_val_buffer() const { return buffer; }
+
     void resetOffset() { set_offset(0); }
     void addOffset(std::size_t offset) { this->offset += offset; }
 };

--- a/clkmgr/pub/clkmgr/client_state.h
+++ b/clkmgr/pub/clkmgr/client_state.h
@@ -46,13 +46,13 @@ class ClientState
 
     /**
      * @brief Copy constructor
-     * @param newState Reference to the new state
+     * @param[in] newState Reference to the new state
      */
     ClientState(ClientState &newState);
 
     /**
      * @brief Set the client state
-     * @param newState Reference to the new state
+     * @param[in] newState Reference to the new state
      */
     void set_clientState(ClientState &newState);
 
@@ -64,7 +64,7 @@ class ClientState
 
     /**
      * @brief Set the connection status
-     * @param state Connection status
+     * @param[in] state Connection status
      */
     void set_connected(bool state);
 
@@ -76,7 +76,7 @@ class ClientState
 
     /**
      * @brief Set the subscription status
-     * @param subscriptionState Subscription status
+     * @param[in] subscriptionState Subscription status
      */
     void set_subscribed(bool subscriptionState);
 
@@ -88,7 +88,7 @@ class ClientState
 
     /**
      * @brief Set the client ID
-     * @param cID Reference to the client ID
+     * @param[in] cID Reference to the client ID
      */
     void set_clientID(TransportClientId &cID);
 
@@ -106,19 +106,19 @@ class ClientState
 
     /**
      * @brief Set the event state counts
-     * @param eCount Event state counts
+     * @param[in] eCount Event state counts
      */
     void set_eventStateCount(clkmgr_event_count eCount);
 
     /**
      * @brief Set the event state
-     * @param eState Event state
+     * @param[in] eState Event state
      */
     void set_eventState(clkmgr_event_state eState);
 
     /**
      * @brief Set the last notification time
-     * @param last_notification_time Last notification time
+     * @param[in] last_notification_time Last notification time
      */
     void set_last_notification_time(struct timespec last_notification_time);
 
@@ -140,8 +140,57 @@ class ClientState
      */
     ClkMgrSubscription &get_eventSub();
 
-    DECLARE_ACCESSOR(sessionId); /**< Declare accessor for sessionId */
-    DECLARE_ACCESSOR(ptp4l_id); /**< Declare accessor for ptp4l_id */
+    /**
+    * @brief Get the constant reference to the session ID.
+    * @return const decltype(sessionId)& Constant reference to the session ID.
+    */
+    const decltype(sessionId) &getc_sessionId() { return sessionId; }
+
+    /**
+    * @brief Get the reference to the session ID.
+    * @return decltype(sessionId)& Reference to the session ID.
+    */
+    decltype(sessionId) &get_sessionId() { return sessionId; }
+
+    /**
+    * @brief Set the session ID.
+    * @param[in] sessionId The new session ID to set.
+    */
+    void set_sessionId(const decltype(sessionId) &sessionId) {
+        this->sessionId = sessionId;
+    }
+
+    /**
+    * @brief Get the value of the session ID.
+    * @return decltype(sessionId) The value of the session ID.
+    */
+    decltype(sessionId) c_get_val_sessionId() const { return sessionId; }
+
+    /**
+    * @brief Get the constant reference to the ptp4l ID.
+    * @return const decltype(ptp4l_id)& Constant reference to the ptp4l ID.
+    */
+    const decltype(ptp4l_id) &getc_ptp4l_id() { return ptp4l_id; }
+
+    /**
+    * @brief Get the reference to the ptp4l ID.
+    * @return decltype(ptp4l_id)& Reference to the ptp4l ID.
+    */
+    decltype(ptp4l_id) &get_ptp4l_id() { return ptp4l_id; }
+
+    /**
+    * @brief Set the ptp4l ID.
+    * @param[in] ptp4l_id The new ptp4l ID to set.
+    */
+    void set_ptp4l_id(const decltype(ptp4l_id) &ptp4l_id) {
+        this->ptp4l_id = ptp4l_id;
+    }
+
+    /**
+    * @brief Get the value of the ptp4l ID.
+    * @return decltype(ptp4l_id) The value of the ptp4l ID.
+    */
+    decltype(ptp4l_id) c_get_val_ptp4l_id() const { return ptp4l_id; }
 };
 
 __CLKMGR_NAMESPACE_END

--- a/clkmgr/pub/clkmgr/subscription.h
+++ b/clkmgr/pub/clkmgr/subscription.h
@@ -76,9 +76,91 @@ class ClkMgrSubscription
 
   public:
     ClkMgrSubscription() noexcept : event_mask(0), composite_event_mask(0) {}
-    DECLARE_ACCESSOR(event_mask); /**< Event mask accessor */
-    DECLARE_ACCESSOR(composite_event_mask); /**< Composite event accessor */
-    DECLARE_ACCESSOR(threshold); /**< Threshold accessor */
+
+    /**
+    * @brief Get the constant reference to the event mask.
+    * @return Constant reference to the event mask.
+    */
+    const decltype(event_mask) &getc_event_mask() { return event_mask; }
+
+    /**
+    * @brief Get the reference to the event mask.
+    * @return Reference to the event mask.
+    */
+    decltype(event_mask) &get_event_mask() { return event_mask; }
+
+    /**
+    * @brief Set the event mask.
+    * @param[in] event_mask The new event mask to set.
+    */
+    void set_event_mask(const decltype(event_mask) &event_mask) {
+        this->event_mask = event_mask;
+    }
+
+    /**
+    * @brief Get the value of the event mask.
+    * @return The value of the event mask.
+    */
+    decltype(event_mask) c_get_val_event_mask() const { return event_mask; }
+
+    /**
+    * @brief Get the constant reference to the composite event mask.
+    * @return Constant reference to the composite event mask.
+    */
+    const decltype(composite_event_mask) &getc_composite_event_mask() {
+        return composite_event_mask;
+    }
+
+    /**
+    * @brief Get the reference to the composite event mask.
+    * @return Reference to the composite event mask.
+    */
+    decltype(composite_event_mask) &get_composite_event_mask() {
+        return composite_event_mask;
+    }
+
+    /**
+    * @brief Set the composite event mask.
+    * @param[in] composite_event_mask The new composite event mask to set.
+    */
+    void set_composite_event_mask(const decltype(composite_event_mask)
+        &composite_event_mask) {
+        this->composite_event_mask = composite_event_mask;
+    }
+
+    /**
+    * @brief Get the value of the composite event mask.
+    * @return The value of the composite event mask.
+    */
+    decltype(composite_event_mask) c_get_val_composite_event_mask() const {
+        return composite_event_mask;
+    }
+
+    /**
+    * @brief Get the constant reference to the threshold.
+    * @return Constant reference to the threshold.
+    */
+    const decltype(threshold) &getc_threshold() { return threshold; }
+
+    /**
+    * @brief Get the reference to the threshold.
+    * @return Reference to the threshold.
+    */
+    decltype(threshold) &get_threshold() { return threshold; }
+
+    /**
+    * @brief Set the threshold.
+    * @param[in] threshold The new threshold to set.
+    */
+    void set_threshold(const decltype(threshold) &threshold) {
+        this->threshold = threshold;
+    }
+
+    /**
+    * @brief Get the value of the threshold.
+    * @return The value of the threshold.
+    */
+    decltype(threshold) c_get_val_threshold() const { return threshold; }
 
     /**
      * @brief Define the upper and lower limits of a specific event

--- a/clkmgr/pub/clkmgr/utility.h
+++ b/clkmgr/pub/clkmgr/utility.h
@@ -24,17 +24,6 @@
 
 __CLKMGR_NAMESPACE_BEGIN
 
-/**
- * @brief Macro to declare accessor functions for a member variable.
- * @param varname The name of the member variable.
- */
-#define DECLARE_ACCESSOR(varname) \
-    const decltype(varname) &getc_##varname() { return varname; } \
-    decltype(varname) &get_##varname() { return varname; } \
-    void set_##varname (const decltype(varname) &varname) \
-    { this->varname = varname; } \
-    decltype(varname) c_get_val_##varname () const { return varname; }
-
 /** Maximum number of character for transport client ID */
 #define TRANSPORT_CLIENTID_LENGTH (512)
 


### PR DESCRIPTION
Refactor the event handling logic to improve readability and maintainability. This includes:
 - Replacing raw pointer casts with static_cast for type safety.
 - Consolidating the handling of TIME_STATUS_NP and PORT_DATA_SET events.
 - Adding support to set the own clock identity as GM identity when the port state is MASTER.
 - Ensuring that the master offset and GM identity are reset when the port state is PASSIVE or lower.
 - Simplifying the logic for setting the synced_to_primary_clock flag based on the port state.
 - Adding comments for clarity and debugging purposes.