### PR TITLE
clkmgr: Fix Incorrect gm_changed event status.

### DIFF
--- a/clkmgr/client/notification_msg.cpp
+++ b/clkmgr/client/notification_msg.cpp
@@ -168,8 +168,7 @@ PROCESS_MESSAGE_TYPE(ClientNotificationMessage::processMessage)
             client_ptp_data->gm_changed_event_count.fetch_add(1,
                 std::memory_order_relaxed);
             clkmgrCurrentState.gm_changed = true;
-        } else
-            clkmgrCurrentState.gm_changed = false;
+        }
         if((eventSub & eventASCapable) &&
             (proxy_data.as_capable != client_ptp_data->as_capable)) {
             client_ptp_data->as_capable = proxy_data.as_capable;

--- a/clkmgr/client/subscribe_msg.cpp
+++ b/clkmgr/client/subscribe_msg.cpp
@@ -246,4 +246,7 @@ void ClientSubscribeMessage::resetClientPtpEventStruct(sessionId_t sID,
         client_ptp_data->synced_to_gm_event_count;
     eventCount.gm_changed_event_count = client_ptp_data->gm_changed_event_count;
     eventCount.composite_event_count = client_ptp_data->composite_event_count;
+    /* Reset gm_changed event if the event count is 0 */
+    if(client_ptp_data->gm_changed_event_count == 0)
+        clkmgrCurrentState->gm_changed = false;
 }


### PR DESCRIPTION
Fix the issue that incorrect gm_changed event status when restarting GM PTP4L on Host system.
Jira link: https://jira.devtools.intel.com/browse/IOTGREALTJ-255

Tested with gm_changed event is updated correctly when there is GM changed with UUID update:
![image](https://github.com/user-attachments/assets/b33fd172-5b53-4680-85f9-ccdeb08eb1f3)
