### PR TITLE
clkmgr: Add support for setting UDS addr for ptp4l and chrony instances.

### DIFF
--- a/clkmgr/client/client_state.cpp
+++ b/clkmgr/client/client_state.cpp
@@ -157,3 +157,32 @@ timespec ClientState::get_last_notification_time() const
 {
     return last_notification_time;
 }
+
+bool ClientState::add_chrony_instance(const UDSAddress &udsAddr)
+{
+    chronyudsAddr = udsAddr;
+    return true;
+}
+
+bool ClientState::add_ptp4l_instance(const UDSAddress &udsAddr,
+    int domainNumber)
+{
+    ptp4ludsAddr = udsAddr;
+    ptp4ldomainNumber = domainNumber;
+    return true;
+}
+
+UDSAddress ClientState::get_ptp4ludsAddr() const
+{
+    return ptp4ludsAddr;
+}
+
+UDSAddress ClientState::get_chronyudsAddr() const
+{
+    return chronyudsAddr;
+}
+
+int ClientState::get_ptp4ldomainNumber() const
+{
+    return ptp4ldomainNumber;
+}

--- a/clkmgr/client/client_state.hpp
+++ b/clkmgr/client/client_state.hpp
@@ -34,6 +34,9 @@ class ClientState
     Event_count eventStateCount = {}; /**< Event count */
     ClkMgrSubscription eventSub = {}; /**< Event subscription */
     timespec last_notification_time; /**< Last notification time */
+    int ptp4ldomainNumber; /**< PTP4L Domain number */
+    UDSAddress ptp4ludsAddr; /**< PTP4L UDS address */
+    UDSAddress chronyudsAddr; /**< Chrony UDS address */
 
   public:
     /**
@@ -166,6 +169,39 @@ class ClientState
     * @return the ptp4l ID.
     */
     uint8_t get_ptp4l_id() const;
+
+    /**
+     * Add the Chrony instance
+     * @param[in] udsAddr UDS address to communicate with Chrony
+     * @return true on success, false on failure
+     */
+    bool add_chrony_instance(const UDSAddress &udsAddr);
+
+    /**
+     * Add the PTP4L instance
+     * @param[in] udsAddr UDS address to communicate with PTP4L
+     * @param[in] domainNumber Domain number used
+     * @return true on success, false on failure
+     */
+    bool add_ptp4l_instance(const UDSAddress &udsAddr, int domainNumber);
+
+    /**
+     * Get the PTP4L UDS address
+     * @return PTP4L UDS address
+     */
+    UDSAddress get_ptp4ludsAddr() const;
+
+    /**
+     * Get the Chrony UDS address
+     * @return Chrony UDS address
+     */
+    UDSAddress get_chronyudsAddr() const;
+
+    /**
+     * Get the PTP4L Domain number
+     * @return PTP4L Domain number
+     */
+    int get_ptp4ldomainNumber() const;
 };
 
 __CLKMGR_NAMESPACE_END

--- a/clkmgr/client/clockmanager.cpp
+++ b/clkmgr/client/clockmanager.cpp
@@ -154,6 +154,17 @@ done:
     return retVal;
 }
 
+bool ClockManager::clkmgr_add_chrony_instance(const UDSAddress &udsAddr)
+{
+    return implClientState->add_chrony_instance(udsAddr);
+}
+
+bool ClockManager::clkmgr_add_ptp4l_instance(const UDSAddress &udsAddr,
+    int domainNumber)
+{
+    return implClientState->add_ptp4l_instance(udsAddr, domainNumber);
+}
+
 int64_t timespec_delta(const timespec &last_notification_time,
     const timespec &current_time)
 {

--- a/clkmgr/client/subscribe_msg.cpp
+++ b/clkmgr/client/subscribe_msg.cpp
@@ -58,6 +58,22 @@ void ClientSubscribeMessage::setClientState(ClientState *newClientState)
     clkmgrCurrentState = &(newClientState->get_eventState());
 }
 
+BUILD_TXBUFFER_TYPE(ClientSubscribeMessage::makeBuffer) const
+{
+    PrintDebug("[ClientSubscribeMessage]::makeBuffer");
+    if(!CommonSubscribeMessage::makeBuffer(TxContext))
+        return false;
+    /* Add UDS address here */
+    if(!WRITE_TX(ARRAY, currentClientState->get_chronyudsAddr(), TxContext))
+        return false;
+    if(!WRITE_TX(ARRAY, currentClientState->get_ptp4ludsAddr(), TxContext))
+        return false;
+    /* Add PTP4L domain number here */
+    if(!WRITE_TX(FIELD, currentClientState->get_ptp4ldomainNumber(), TxContext))
+        return false;
+    return true;
+}
+
 PARSE_RXBUFFER_TYPE(ClientSubscribeMessage::parseBuffer)
 {
     ptp_event data = {};

--- a/clkmgr/client/subscribe_msg.hpp
+++ b/clkmgr/client/subscribe_msg.hpp
@@ -33,6 +33,7 @@ class ClientSubscribeMessage : virtual public
 
   public:
     ClientSubscribeMessage() : MESSAGE_SUBSCRIBE() {};
+    virtual BUILD_TXBUFFER_TYPE(makeBuffer) const;
 
     static rtpi::mutex cv_mtx;
     static rtpi::condition_variable cv;

--- a/clkmgr/proxy/subscribe_msg.cpp
+++ b/clkmgr/proxy/subscribe_msg.cpp
@@ -59,6 +59,35 @@ BUILD_TXBUFFER_TYPE(ProxySubscribeMessage::makeBuffer) const
     return true;
 }
 
+PARSE_RXBUFFER_TYPE(ProxySubscribeMessage::parseBuffer)
+{
+    std::string chronyUDSAddr;
+    std::string ptp4lUDSAddr;
+    int ptp4lDomainNumber;
+    UDSAddress chronyAddr;
+    UDSAddress ptp4lAddr;
+    PrintDebug("[ProxySubscribeMessage]::parseBuffer ");
+    if(!CommonSubscribeMessage::parseBuffer(LxContext))
+        return false;
+    /* Retrieve ptp4l and chrony UDS addresses */
+    if(!PARSE_RX(ARRAY, chronyAddr, LxContext))
+        return false;
+    if(!PARSE_RX(ARRAY, ptp4lAddr, LxContext))
+        return false;
+    /* Retrieve ptp4l domain number */
+    if(!PARSE_RX(FIELD, ptp4lDomainNumber, LxContext))
+        return false;
+    /* Convert array to string */
+    chronyUDSAddr.assign(chronyAddr.begin(), chronyAddr.end());
+    ptp4lUDSAddr.assign(ptp4lAddr.begin(), ptp4lAddr.end());
+    PrintDebug("[ProxySubscribeMessage] Chrony UDS address: " + chronyUDSAddr);
+    PrintDebug("[ProxySubscribeMessage] PTP4L UDS address: " + ptp4lUDSAddr);
+    PrintDebug("[ProxySubscribeMessage] PTP4L Domain Number: " +
+        std::to_string(ptp4lDomainNumber));
+    /* ToDo: communicate to Chrony and ptp4l only after get the uds addr */
+    return true;
+}
+
 /*
 This is to process the subscription from the clkmgr client runtime
 via POSIX msg queue.

--- a/clkmgr/proxy/subscribe_msg.hpp
+++ b/clkmgr/proxy/subscribe_msg.hpp
@@ -26,6 +26,8 @@ class ProxySubscribeMessage : virtual public ProxyMessage,
   public:
     virtual PROCESS_MESSAGE_TYPE(processMessage);
     virtual BUILD_TXBUFFER_TYPE(makeBuffer) const;
+    virtual PARSE_RXBUFFER_TYPE(parseBuffer);
+
     /**
      * Create the ProxyConnectMessage object
      * @param msg msg structure to be fill up

--- a/clkmgr/pub/clkmgr/utility.h
+++ b/clkmgr/pub/clkmgr/utility.h
@@ -32,6 +32,12 @@ const int TRANSPORT_CLIENTID_LENGTH = 512;
 /** Array to store transport client ID. */
 typedef std::array<uint8_t, TRANSPORT_CLIENTID_LENGTH> TransportClientId;
 
+/** Maximum number of character for UDS address. */
+const int UDS_ADDRESS_LENGTH = 64;
+
+/** Array to store UDS address. */
+typedef std::array<uint8_t, UDS_ADDRESS_LENGTH> UDSAddress;
+
 /** Type definition for session ID. */
 typedef uint16_t sessionId_t;
 

--- a/clkmgr/pub/clockmanager.h
+++ b/clkmgr/pub/clockmanager.h
@@ -70,6 +70,21 @@ class ClockManager
     bool clkmgr_disconnect();
 
     /**
+     * Add the Chrony instance
+     * @param[in] udsAddr unix domain address to communicate with Chrony
+     * @return true on success, false on failure
+     */
+    bool clkmgr_add_chrony_instance(const UDSAddress &udsAddr);
+
+    /**
+     * Add the ptp4l instance
+     * @param[in] udsAddr unix domain address to communicate with ptp4l
+     * @param[in] domainNumber domain number used
+     * @return true on success, false on failure
+     */
+    bool clkmgr_add_ptp4l_instance(const UDSAddress &udsAddr, int domainNumber);
+
+    /**
      * Subscribe to events
      * @param[in] newSub Reference to the new subscription
      * @param[out] currentState Reference to the current state

--- a/clkmgr/sample/clkmgr_test.cpp
+++ b/clkmgr/sample/clkmgr_test.cpp
@@ -53,6 +53,8 @@ int main(int argc, char *argv[])
     int32_t  gmOffsetUpperLimit = 100000;
     int32_t  chronyGmOffsetLowerLimit = -100000;
     int32_t  chronyGmOffsetUpperLimit = 100000;
+    UDSAddress ptp4lAddr = {"/var/run/ptp4l"};
+    UDSAddress chronyAddr = {"/var/run/chrony/chronyd.sock"};
     int ret = EXIT_SUCCESS;
     uint32_t idleTime = 1;
     uint32_t timeout = 10;
@@ -165,6 +167,17 @@ int main(int argc, char *argv[])
 
     if (!cm.clkmgr_connect()) {
         std::cout << "[clkmgr] failure in connecting !!!\n";
+        ret = EXIT_FAILURE;
+        goto do_exit;
+    }
+
+    if (!cm.clkmgr_add_ptp4l_instance(ptp4lAddr, 0)) {
+        std::cout << "[clkmgr] failure in setting ptp4l UDS address !!!\n";
+        ret = EXIT_FAILURE;
+        goto do_exit;
+    }
+    if (!cm.clkmgr_add_chrony_instance(chronyAddr)) {
+        std::cout << "[clkmgr] failure in setting chrony UDS address !!!\n";
         ret = EXIT_FAILURE;
         goto do_exit;
     }


### PR DESCRIPTION
- Added methods to `ClientState` class to set and get UDS addresses for ptp4l and chrony instances.
- Updated `ClockManager` class to include methods for adding ptp4l and chrony instances with UDS addresses.
- Modified `ClientSubscribeMessage` and `ProxySubscribeMessage` classes to handle UDS addresses in the message buffer.
- Updated `clkmgr_test.cpp` to set ptp4l and chrony UDS addresses to `/var/run/ptp4l` and `/var/run/chrony/chronyd.sock` respectively.

![image](https://github.com/user-attachments/assets/811989e3-ba67-4950-9b2d-af236215dc8d)

