### PR TITLE
clkmgr: Add API for clkmgr_gettime()

### DIFF
--- a/clkmgr/HLD_clkmgr.md
+++ b/clkmgr/HLD_clkmgr.md
@@ -86,19 +86,22 @@ disconnect message.
 - It will delete the ptp event for subscription and state reference for
 notification.
 
+5. clkmgr_gettime()
+- This function retrieve the time of the CLOCK_REALTIME.
+
 ## Available API for c sample application
 
 1. clkmgr_c_connect()
-This function will establish a connection to the clkmgr_proxy. Once connected,
+- This function will establish a connection to the clkmgr_proxy. Once connected,
 it will assign client ID for the client_runtime that connected to the
 clkmgr_proxy.
 
 2. clkmgr_c_subscribe()
-This function generates a subscribe message signaling interest in specific
+- This function generates a subscribe message signaling interest in specific
 supported event types.
 
 3. clkmgr_c_status_wait()
-This function waits for a specified timeout period for any event changes. The
+- This function waits for a specified timeout period for any event changes. The
 wait function blocks until an undelivered event is queued. If the event is
 already queued for delivery when the wait function is called, the call exits
 immediately, returning the queued event notification(s). Multiple event
@@ -111,9 +114,12 @@ timeout is equal to -1, this function wait infinite until there is event changes
 occurs.
 
 4. clkmgr_c_disconnect()
-This function performs disconnect process with clkmgr_proxy by sending
+- This function performs disconnect process with clkmgr_proxy by sending
 disconnect message.  It will delete the ptp event for subscription and state
 reference for notification.
 
 5. clkmgr_c_client_fetch()
-This function fetch the single client object and return a pointer to it
+- This function fetch the single client object and return a pointer to it
+
+6. clkmgr_c_gettime()
+- This function retrieve the time of the CLOCK_REALTIME.

--- a/clkmgr/client/clockmanager.cpp
+++ b/clkmgr/client/clockmanager.cpp
@@ -254,3 +254,9 @@ int ClockManager::clkmgr_status_wait(int timeout,
     implClientState->set_eventStateCount(eventCount);
     return 1;
 }
+
+int ClockManager::clkmgr_gettime(timespec *ts)
+{
+    clockid_t clk_id = CLOCK_REALTIME;
+    return clock_gettime(clk_id, ts);
+}

--- a/clkmgr/client/clockmanager_c.cpp
+++ b/clkmgr/client/clockmanager_c.cpp
@@ -110,3 +110,10 @@ int clkmgr_c_status_wait(clkmgr_c_client_ptr client_ptr, int timeout,
     }
     return ret;
 }
+
+int clkmgr_c_gettime(clkmgr_c_client_ptr client_ptr, struct timespec *ts)
+{
+    if(client_ptr == nullptr)
+        return -1;
+    return static_cast<clkmgr::ClockManager *>(client_ptr)->clkmgr_gettime(ts);
+}

--- a/clkmgr/pub/clkmgr/clockmanager_c.h
+++ b/clkmgr/pub/clkmgr/clockmanager_c.h
@@ -13,6 +13,7 @@
 #define CLKMGR_CLOCKMANAGER_C_H
 
 #include "pub/clkmgr/types_c.h"
+#include <time.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -76,6 +77,14 @@ bool clkmgr_c_subscribe(clkmgr_c_client_ptr client_ptr,
 int clkmgr_c_status_wait(clkmgr_c_client_ptr client_ptr, int timeout,
     struct Clkmgr_Event_state *current_state,
     struct Clkmgr_Event_count *current_count);
+
+/**
+ * Retrieve the time of the CLOCK_REALTIME
+ * @param[in, out] client_ptr Pointer to the client instance
+ * @param[out] ts timestamp of the CLOCK_REALTIME
+ * @return 0 on success, -1 on failure
+ */
+int clkmgr_c_gettime(clkmgr_c_client_ptr client_ptr, struct timespec *ts);
 
 #ifdef __cplusplus
 }

--- a/clkmgr/pub/clockmanager.h
+++ b/clkmgr/pub/clockmanager.h
@@ -108,6 +108,13 @@ class ClockManager
      */
     int clkmgr_status_wait(int timeout, Event_state &currentState,
         Event_count &currentCount);
+
+    /**
+     * Retrieve the time of the CLOCK_REALTIME
+     * @param[out] ts timestamp of the CLOCK_REALTIME
+     * @return 0 on success, -1 on failure
+     */
+    int clkmgr_gettime(timespec *ts);
 };
 
 __CLKMGR_NAMESPACE_END

--- a/clkmgr/sample/clkmgr_c_test.c
+++ b/clkmgr/sample/clkmgr_c_test.c
@@ -43,6 +43,7 @@ int main(int argc, char *argv[])
     int ret = EXIT_SUCCESS;
     uint32_t idle_time = 1;
     uint32_t timeout = 10;
+    struct timespec ts;
     int retval;
     int option;
 
@@ -173,6 +174,12 @@ int main(int argc, char *argv[])
 
     printf("[clkmgr][%.3f] Obtained data from Subscription Event:\n",
         getMonotonicTime());
+    if (clkmgr_c_gettime(client_ptr, &ts)) {
+        perror("clock_c_gettime failed");
+    } else {
+        printf("[clkmgr] Current Time of CLOCK_REALTIME: %ld ns\n",
+            (ts.tv_sec * 1000000000) + ts.tv_nsec);
+    }
     printf("+---------------------------+------------------------+\n");
     printf("| %-25s | %-22s |\n", "Event", "Event Status");
     if (subscription.event_mask) {
@@ -253,6 +260,12 @@ int main(int argc, char *argv[])
 
         printf("[clkmgr][%.3f] Obtained data from Notification Event:\n",
             getMonotonicTime());
+        if (clkmgr_c_gettime(client_ptr, &ts)) {
+            perror("clock_c_gettime failed");
+        } else {
+            printf("[clkmgr] Current Time of CLOCK_REALTIME: %ld ns\n",
+                (ts.tv_sec * 1000000000) + ts.tv_nsec);
+        }
         printf("+---------------------------+--------------+-------------+\n");
         printf("| %-25s | %-12s | %-11s |\n", "Event", "Event Status",
             "Event Count");

--- a/clkmgr/sample/clkmgr_test.cpp
+++ b/clkmgr/sample/clkmgr_test.cpp
@@ -31,7 +31,7 @@ void signal_handler(int sig)
 }
 
 double getMonotonicTime() {
-    struct timespec timeSpec;
+    timespec timeSpec;
 
     if (clock_gettime(CLOCK_MONOTONIC, &timeSpec) == -1) {
         perror("clock_gettime failed");
@@ -58,6 +58,7 @@ int main(int argc, char *argv[])
     int ret = EXIT_SUCCESS;
     uint32_t idleTime = 1;
     uint32_t timeout = 10;
+    timespec ts;
     int retval;
     int option;
 
@@ -207,6 +208,12 @@ int main(int argc, char *argv[])
 
     printf("[clkmgr][%.3f] Obtained data from Subscription Event:\n",
         getMonotonicTime());
+    if (cm.clkmgr_gettime(&ts)) {
+        perror("clock_gettime failed");
+    } else {
+        printf("[clkmgr] Current Time of CLOCK_REALTIME: %ld ns\n",
+            (ts.tv_sec * 1000000000) + ts.tv_nsec);
+    }
     printf("+---------------------------+------------------------+\n");
     printf("| %-25s | %-22s |\n", "Event", "Event Status");
     if (event2Sub) {
@@ -287,6 +294,12 @@ int main(int argc, char *argv[])
 
         printf("[clkmgr][%.3f] Obtained data from Notification Event:\n",
             getMonotonicTime());
+        if (cm.clkmgr_gettime(&ts)) {
+            perror("clock_gettime failed");
+        } else {
+            printf("[clkmgr] Current Time of CLOCK_REALTIME: %ld ns\n",
+                (ts.tv_sec * 1000000000) + ts.tv_nsec);
+        }
         printf("+---------------------------+--------------+-------------+\n");
         printf("| %-25s | %-12s | %-11s |\n", "Event", "Event Status",
             "Event Count");


### PR DESCRIPTION
Add API for clkmgr_gettime() to retrieve time of the specified clock clk_id.