### PR TITLE
clkmgr: Add support for dynamic UDS address for ptp4l and chrony.

### DIFF
--- a/clkmgr/client/connect_msg.cpp
+++ b/clkmgr/client/connect_msg.cpp
@@ -52,9 +52,6 @@ PARSE_RXBUFFER_TYPE(ClientConnectMessage::parseBuffer)
     PrintDebug("[ClientConnectMessage]::parseBuffer ");
     if(!CommonConnectMessage::parseBuffer(LxContext))
         return false;
-    if(!PARSE_RX(FIELD, data.ptp4l_id, LxContext))
-        return false;
-    currentClientState->set_ptp4l_id(data.ptp4l_id);
     return true;
 }
 

--- a/clkmgr/proxy/connect_chrony.cpp
+++ b/clkmgr/proxy/connect_chrony.cpp
@@ -146,10 +146,10 @@ void start_monitor_thread(chrony_session *s, int report_index)
     }
 }
 
-void ConnectChrony::connect_chrony()
+void ConnectChrony::connect_chrony(std::string chronyUdsAddress)
 {
     /* connect to chronyd unix socket*/
-    fd = chrony_open_socket("/var/run/chrony/chronyd.sock");
+    fd = chrony_open_socket(chronyUdsAddress.c_str());
     chrony_session *s;
     if(chrony_init_session(&s, fd) == CHRONY_OK) {
         start_monitor_thread(s, report_index);

--- a/clkmgr/proxy/connect_chrony.hpp
+++ b/clkmgr/proxy/connect_chrony.hpp
@@ -17,7 +17,7 @@ __CLKMGR_NAMESPACE_BEGIN
 class ConnectChrony
 {
   public:
-    static void connect_chrony();
+    static void connect_chrony(std::string chronyUdsAddress);
 };
 
 __CLKMGR_NAMESPACE_END

--- a/clkmgr/proxy/connect_msg.cpp
+++ b/clkmgr/proxy/connect_msg.cpp
@@ -68,11 +68,6 @@ PROCESS_MESSAGE_TYPE(ProxyConnectMessage::processMessage)
 {
     sessionId_t newSessionId = this->getc_sessionId();
     PrintDebug("Processing proxy connect message");
-    /* Check whether there is ptp4l available */
-    if(!clockEvent.ptp4l_id) {
-        PrintError("ptp4l_id is not available.");
-        return false;
-    }
     if(newSessionId != InvalidSessionId) {
         auto clientSession = Client::GetClientSession(newSessionId);
         if(clientSession)
@@ -98,9 +93,6 @@ BUILD_TXBUFFER_TYPE(ProxyConnectMessage::makeBuffer) const
 {
     PrintDebug("[ProxyConnectMessage]::makeBuffer");
     if(!CommonConnectMessage::makeBuffer(TxContext))
-        return false;
-    /* Add ptp4l_id here */
-    if(!WRITE_TX(FIELD, clockEvent.ptp4l_id, TxContext))
         return false;
     return true;
 }

--- a/clkmgr/proxy/connect_ptp4l.cpp
+++ b/clkmgr/proxy/connect_ptp4l.cpp
@@ -36,6 +36,7 @@ static ptpmgmt::SockUnix sku;
 static ptpmgmt::SockBase *sk = &sku;
 static ptpmgmt::SUBSCRIBE_EVENTS_NP_t events_tlv;
 ptp_event clockEvent = { 0 };
+extern uint8_t cmGlobalTransportSpecific;
 
 void notify_client()
 {
@@ -287,22 +288,22 @@ void *ptp4l_event_loop(void *arg)
  *         Returns 0 on success, or -1 if an error occurs during socket
  *         initialization, address setting, or epoll configuration.
  */
-int Connect::connect(uint8_t transport_specific)
+int ConnectPtp4l::connect_ptp4l(std::string ptp4lUdsAddress, uint8_t domain)
 {
-    clockEvent.ptp4l_id = 1;
-    const char *uds_address = "/var/run/ptp4l";
+    clockEvent.ptp4l_id = domain;
     if(!sku.setDefSelfAddress() || !sku.init() ||
-        !sku.setPeerAddress(uds_address))
+        !sku.setPeerAddress(ptp4lUdsAddress.c_str()))
         return -1;
     /* Set Transport Specific */
     MsgParams prms = msg.getParams();
-    prms.transportSpecific = transport_specific;
+    prms.transportSpecific = cmGlobalTransportSpecific;
+    prms.domainNumber = domain;
     msg.updateParams(prms);
     handle_connect();
     return 0;
 }
 
-void Connect::disconnect()
+void ConnectPtp4l::disconnect_ptp4l()
 {
     sk->close();
 }

--- a/clkmgr/proxy/connect_ptp4l.hpp
+++ b/clkmgr/proxy/connect_ptp4l.hpp
@@ -14,12 +14,12 @@
 
 __CLKMGR_NAMESPACE_BEGIN
 
-class Connect
+class ConnectPtp4l
 {
   private:
   public:
-    static int connect(uint8_t transport_specific);
-    static void disconnect();
+    static int connect_ptp4l(std::string ptp4lUdsAddress, uint8_t domain);
+    static void disconnect_ptp4l();
 };
 
 __CLKMGR_NAMESPACE_END

--- a/clkmgr/proxy/main.cpp
+++ b/clkmgr/proxy/main.cpp
@@ -24,10 +24,10 @@
 __CLKMGR_NAMESPACE_USE;
 
 using namespace std;
+uint8_t cmGlobalTransportSpecific = 0;
 
 int main(int argc, char *argv[])
 {
-    uint8_t transport_specific = 0;
     int value = 0;
     int opt;
     while((opt = getopt(argc, argv, "t:h")) != -1) {
@@ -39,14 +39,14 @@ int main(int argc, char *argv[])
                         optarg);
                     return EXIT_FAILURE;
                 }
-                transport_specific = static_cast<uint8_t>(value);
+                cmGlobalTransportSpecific = static_cast<uint8_t>(value);
                 break;
             case 'h':
                 printf("Usage of %s:\n"
                     "Options:\n"
                     " -t transport specific\n"
                     "    Default: 0x%x\n",
-                    argv[0], transport_specific);
+                    argv[0], cmGlobalTransportSpecific);
                 return EXIT_SUCCESS;
             default:
                 fprintf(stderr, "Usage of %s:\n"
@@ -54,7 +54,7 @@ int main(int argc, char *argv[])
                     " -t transport specific\n"
                     "    Default: 0x%x\n",
                     argv[0],
-                    transport_specific);
+                    cmGlobalTransportSpecific);
                 return EXIT_FAILURE;
         }
     }
@@ -67,13 +67,9 @@ int main(int argc, char *argv[])
         PrintError("Message init failed");
         return EXIT_FAILURE;
     }
-    #ifdef HAVE_LIBCHRONY
-    ConnectChrony::connect_chrony();
-    #endif
-    Connect::connect(transport_specific);
     WaitForStopSignal();
     PrintDebug("Got stop signal");
-    Connect::disconnect();
+    ConnectPtp4l::disconnect_ptp4l();
     if(!ProxyTransport::stop()) {
         PrintError("stop failed");
         return EXIT_FAILURE;

--- a/clkmgr/proxy/subscribe_msg.cpp
+++ b/clkmgr/proxy/subscribe_msg.cpp
@@ -14,6 +14,8 @@
 #include "common/print.hpp"
 #include "common/serialize.hpp"
 #include "proxy/client.hpp"
+#include "proxy/connect_chrony.hpp"
+#include "proxy/connect_ptp4l.hpp"
 #include "proxy/subscribe_msg.hpp"
 
 __CLKMGR_NAMESPACE_USE;
@@ -84,7 +86,10 @@ PARSE_RXBUFFER_TYPE(ProxySubscribeMessage::parseBuffer)
     PrintDebug("[ProxySubscribeMessage] PTP4L UDS address: " + ptp4lUDSAddr);
     PrintDebug("[ProxySubscribeMessage] PTP4L Domain Number: " +
         std::to_string(ptp4lDomainNumber));
-    /* ToDo: communicate to Chrony and ptp4l only after get the uds addr */
+    ConnectPtp4l::connect_ptp4l(ptp4lUDSAddr, ptp4lDomainNumber);
+    #ifdef HAVE_LIBCHRONY
+    ConnectChrony::connect_chrony(chronyUDSAddr);
+    #endif
     return true;
 }
 


### PR DESCRIPTION
This patch enhances the clkmgr by adding support for dynamic Unix Domain Socket (UDS) addresses and domain numbers for ptp4l and chrony.

Tested with ptp4l and chrony running:
![image](https://github.com/user-attachments/assets/e17bd861-2758-4c48-8464-c9289fa94345)
