### PR TITLE
clkmgr: Add multi-domain support for ptp4l and session-based event handling.

### DIFF
--- a/clkmgr/common/ptp_event.hpp
+++ b/clkmgr/common/ptp_event.hpp
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <cstdint>
+#include <vector>
 
 __CLKMGR_NAMESPACE_BEGIN
 
@@ -28,6 +29,7 @@ struct ptp_event {
     int64_t chrony_offset;
     uint32_t chrony_reference_id;
     int64_t polling_interval;
+    uint8_t domain_number;
 };
 
 struct client_ptp_event {

--- a/clkmgr/proxy/connect_ptp4l.hpp
+++ b/clkmgr/proxy/connect_ptp4l.hpp
@@ -18,7 +18,8 @@ class ConnectPtp4l
 {
   private:
   public:
-    static int connect_ptp4l(std::string ptp4lUdsAddress, uint8_t domain);
+    static int connect_ptp4l(std::string ptp4lUdsAddress, uint8_t domain,
+        uint8_t sessionId);
     static void disconnect_ptp4l();
 };
 

--- a/clkmgr/proxy/notification_msg.hpp
+++ b/clkmgr/proxy/notification_msg.hpp
@@ -24,6 +24,8 @@ __CLKMGR_NAMESPACE_BEGIN
 class ProxyNotificationMessage : virtual public ProxyMessage,
     virtual public NotificationMessage
 {
+  private:
+    sessionId_t sessionId;
   public:
     ProxyNotificationMessage() : MESSAGE_NOTIFY() {}
     virtual PROCESS_MESSAGE_TYPE(processMessage);
@@ -42,6 +44,12 @@ class ProxyNotificationMessage : virtual public ProxyMessage,
      * @return true
      */
     static bool initMessage();
+    void setSessionId(sessionId_t sessionId) {
+        this->sessionId = sessionId;
+    }
+    sessionId_t getSessionId() const {
+        return sessionId;
+    }
 };
 
 __CLKMGR_NAMESPACE_END

--- a/clkmgr/proxy/subscribe_msg.cpp
+++ b/clkmgr/proxy/subscribe_msg.cpp
@@ -86,7 +86,9 @@ PARSE_RXBUFFER_TYPE(ProxySubscribeMessage::parseBuffer)
     PrintDebug("[ProxySubscribeMessage] PTP4L UDS address: " + ptp4lUDSAddr);
     PrintDebug("[ProxySubscribeMessage] PTP4L Domain Number: " +
         std::to_string(ptp4lDomainNumber));
-    ConnectPtp4l::connect_ptp4l(std::move(ptp4lUDSAddr), ptp4lDomainNumber);
+    sessionId_t sID;
+    sID = this->getc_sessionId();
+    ConnectPtp4l::connect_ptp4l(ptp4lUDSAddr, ptp4lDomainNumber, sID);
     #ifdef HAVE_LIBCHRONY
     ConnectChrony::connect_chrony(std::move(chronyUDSAddr));
     #endif


### PR DESCRIPTION
This patch enhances the clkmgr by adding support for multiple domains in ptp4l and session-based event handling.

- Updated `ptp_event` structure to include `domain_number` and `session_id` fields.
- Modified `connect_ptp4l` function to accept `sessionId` and handle multiple domains.
- Implemented session-based event handling in `notify_client` and `event_handle` functions.
- Updated `ProxyNotificationMessage` to include `setSessionId` and `getSessionId` methods.
- Adjusted `makeBuffer` function in `ProxyNotificationMessage` to handle session-specific `ptp_event` data.
- Ensured proper initialization and usage of `ptp_event_map` to store and retrieve `ptp_event` data based on domain and session.

1. Tested by running 2 sample apps, and both subscribe each one domain number (left: domain 1, right: domain 0):
![image](https://github.com/user-attachments/assets/b74d2e12-7a08-4c50-967c-ae893b6b7f88)

2. Tested by running 2 sample apps, and both subscribe to same domain number (domain 0):
![image](https://github.com/user-attachments/assets/384b7433-2d71-4cc5-9718-782a7743aa76)

3. Tested by running 2 sample apps, and both subscribe each one domain number with different log sync interval (left: domain 1, right: domain 0):
![image](https://github.com/user-attachments/assets/3d894f23-8629-428d-83a9-3097caedccb4)
