### PR TITLE
clkmgr: Update Chrony's field name to latest libchrony.

### DIFF
--- a/clkmgr/proxy/connect_chrony.cpp
+++ b/clkmgr/proxy/connect_chrony.cpp
@@ -99,10 +99,10 @@ static int subscribe_to_chronyd(chrony_session *s, int report_index,
         if(content == CHRONY_CONTENT_NONE)
             continue;
         const char *field_name = chrony_get_field_name(s, j);
-        if(field_name != nullptr && strcmp(field_name, "Reference ID") == 0)
+        if(field_name != nullptr && strcmp(field_name, "reference ID") == 0)
             ptp4lEvents[timeBaseIndex].chrony_reference_id =
                 chrony_get_field_uinteger(s, j);
-        if(field_name != nullptr && strcmp(field_name, "Poll") == 0) {
+        if(field_name != nullptr && strcmp(field_name, "poll") == 0) {
             int32_t interval = static_cast<int32_t>
                 (static_cast<int16_t>(chrony_get_field_integer(s, j)));
             ptp4lEvents[timeBaseIndex].polling_interval =
@@ -113,7 +113,7 @@ static int subscribe_to_chronyd(chrony_session *s, int report_index,
             #endif
         }
         if(field_name != nullptr && strcmp(field_name,
-                "Last sample offset (original)") == 0) {
+                "original last sample offset") == 0) {
             float second = (chrony_get_field_float(s, j) * 1e9);
             ptp4lEvents[timeBaseIndex].chrony_offset = (int)second;
             #if 0


### PR DESCRIPTION
These changes ensure that the correct fields are identified and processed when subscribing to Chrony events.

1. Tested by running sample apps with 2 chrony daemon:
![image](https://github.com/user-attachments/assets/144c9f86-af8c-4537-a1ef-df4225fdafba)

2. Proxy printout chrony data (reference id, offset, pool interval) for 2 chrony daemon:
![image](https://github.com/user-attachments/assets/964307d2-0980-48ac-a0da-99285d603b20)
