### PR TITLE
clkmgr: Simplify message handling

### DIFF
--- a/.github/workflows/build_gentoo.yml
+++ b/.github/workflows/build_gentoo.yml
@@ -8,6 +8,7 @@
 ###############################################################################
 
 name: build gentoo docker image
+permissions: read-all
 
 # Start manually
 on: workflow_dispatch
@@ -18,10 +19,6 @@ env:
 jobs:
   gentoo:
     runs-on: ubuntu-24.04
-    # Sets permissions of the GITHUB_TOKEN to allow upload new container
-    permissions:
-      contents: read
-      packages: write
 
     steps:
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -21,15 +21,19 @@ jobs:
   coverity:
     runs-on: ubuntu-24.04
     steps:
-
-    - name: checkout repository
-      uses: actions/checkout@v4
-
+    - name: Install dependencies
+      run: sudo apt-get install -y swig libtool libtool-bin
+    - name: Install librtpi
+      run: git clone https://github.com/linux-rt/librtpi.git && cd librtpi && autoreconf --install && ./configure && sudo make install && cd - && sudo rm -rf librtpi
+    - name: Install libchrony
+      run: git clone https://gitlab.com/chrony/libchrony.git && cd libchrony && make && sudo make install prefix=/usr/local && cd - && sudo rm -rf libchrony
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: autoreconf
+      run: autoreconf -i
     - name: configure
-      run: tools/ci_coverity.sh
-
-    - name: coverity scan
-      uses: vapier/coverity-scan-action@v1
+      run: ./configure
+    - uses: vapier/coverity-scan-action@2068473c7bdf8c2fb984a6a40ae76ee7facd7a85 # v1.8.0
       with:
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        project: libptpmgmt_iaclocklib

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -9,18 +9,13 @@
 ###############################################################################
 
 name: deploy doxygen documents
+permissions: read-all
 
 # Deploy after release a new version, or manually
 on:
   workflow_dispatch:
   release:
     types: published
-
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment
 concurrency:

--- a/.github/workflows/virus_scan.yml
+++ b/.github/workflows/virus_scan.yml
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: LGPL-3.0-or-later
+# SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation. All rights reserved.
+#
+# @author Song Yoong Siang <yoong.siang.song@intel.com>
+# @copyright © 2024 Intel Corporation. All rights reserved.
+# @license LGPL-3.0-or-later
+#
+# scan virus
+###############################################################################
+
+name: "Virus Scan"
+permissions: read-all
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  job_id:
+    name: Scan Virus
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.0.0
+        with:
+          fetch-depth: 0
+      - name: Scan Repository
+        uses: hugoalh/scan-virus-ghaction@v0.20.0
+        with:
+          statistics_summary: True

--- a/README.md
+++ b/README.md
@@ -180,3 +180,7 @@ The Licence of this project is
   * The library is under LGPL v3 or later.
   * The pmc and phc_ctl tools and the testing scripts are under GPL v3 or later.
   * Documentation is under under GFDL v1.3 or later without invariants sections.
+
+# <u>Disclaimer</u>
+This project is under development. All source code and features on the main
+branch are for the purpose of testing or evaluation and not production ready.

--- a/clkmgr/proxy/main.cpp
+++ b/clkmgr/proxy/main.cpp
@@ -14,6 +14,7 @@
 
 #include "common/print.hpp"
 #include "common/sighandler.hpp"
+#include "proxy/config_parser.hpp"
 #include "proxy/connect_ptp4l.hpp"
 #ifdef HAVE_LIBCHRONY
 #include "proxy/connect_chrony.hpp"
@@ -93,6 +94,16 @@ int main(int argc, char *argv[])
         PrintError("Message init failed");
         return EXIT_FAILURE;
     }
+    timeBaseCfgs = {
+        {
+            1, "with chrony domain 1", "/var/run/chrony/chronyd.sock",
+            "/var/run/master-domain-1", "enp1s0", 1, 2
+        },
+        {
+            2, "with chrony domain 0", "/var/run/chrony/chronyd-server1.sock",
+            "/var/run/master-domain-0", "enp1s0", 1, 0
+        }
+    }; // TO BE REMOVED
     ConnectPtp4l::connect_ptp4l();
     #ifdef HAVE_LIBCHRONY
     ConnectChrony::connect_chrony();

--- a/clkmgr/proxy/subscribe_msg.cpp
+++ b/clkmgr/proxy/subscribe_msg.cpp
@@ -23,6 +23,9 @@ __CLKMGR_NAMESPACE_USE;
 using namespace std;
 
 extern std::map<int, ptp_event> ptp4lEvents;
+int timeBaseIndexTest[2] = {2, 1}; // TO BE REMOVED
+int i = 0; // TO BE REMOVED
+int j = 0; // TO BE REMOVED
 
 /**
  * Create the ProxySubscribeMessage object
@@ -55,7 +58,8 @@ BUILD_TXBUFFER_TYPE(ProxySubscribeMessage::makeBuffer) const
     PrintDebug("[ProxySubscribeMessage]::makeBuffer");
     if(!CommonSubscribeMessage::makeBuffer(TxContext))
         return false;
-    ptp_event event = ptp4lEvents[timeBaseIndex];
+    ptp_event event = ptp4lEvents[timeBaseIndexTest[j]];
+    j++; // TO BE REMOVED
     /* Add ptp data here */
     if(!WRITE_TX(FIELD, event, TxContext))
         return false;
@@ -67,9 +71,10 @@ PARSE_RXBUFFER_TYPE(ProxySubscribeMessage::parseBuffer)
     PrintDebug("[ProxySubscribeMessage]::parseBuffer ");
     if(!CommonSubscribeMessage::parseBuffer(LxContext))
         return false;
-    ConnectPtp4l::subscribe_ptp4l(timeBaseIndex, this->getc_sessionId());
+    ConnectPtp4l::subscribe_ptp4l(timeBaseIndexTest[i], this->getc_sessionId());
+    i++; // TO BE REMOVED
     #ifdef HAVE_LIBCHRONY
-    ConnectChrony::subscribe_chrony(std::move(timeBaseIndex),
+    ConnectChrony::subscribe_chrony(std::move(timeBaseIndexTest[i]),
         this->getc_sessionId());
     #endif
     return true;

--- a/clkmgr/proxy/subscribe_msg.hpp
+++ b/clkmgr/proxy/subscribe_msg.hpp
@@ -22,7 +22,7 @@ class ProxySubscribeMessage : virtual public ProxyMessage,
     virtual public CommonSubscribeMessage
 {
   private:
-    int timeBaseIndex;
+    //int timeBaseIndex;
   protected:
     ProxySubscribeMessage() : MESSAGE_SUBSCRIBE() {};
   public:

--- a/doc/CODE_OF_CONDUCT.md
+++ b/doc/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+<!-- SPDX-License-Identifier: GFDL-1.3-no-invariants-or-later
+     SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation. All rights reserved. -->
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+CommunityCodeOfConduct AT intel DOT com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq

--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+<!-- SPDX-License-Identifier: GFDL-1.3-no-invariants-or-later
+     SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation. All rights reserved. -->
+# Contributing
+
+### License
+
+<PROJECT NAME> is licensed under the terms in [LICENSE]<link to license file in repo>. By contributing to the project, you agree to the license and copyright terms therein and release your contribution under these terms.
+
+### Sign your work
+
+Please use the sign-off line at the end of the patch. Your signature certifies that you wrote the patch or otherwise have the right to pass it on as an open-source patch. The rules are pretty simple: if you can certify
+the below (from [developercertificate.org](http://developercertificate.org/)):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+660 York Street, Suite 102,
+San Francisco, CA 94110 USA
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```
+
+Then you just add a line to every git commit message:
+
+    Signed-off-by: Joe Smith <joe.smith@email.com>
+
+Use your real name (sorry, no pseudonyms or anonymous contributions.)
+
+If you set your `user.name` and `user.email` git configs, you can sign your
+commit automatically with `git commit -s`.

--- a/doc/SECURITY.md
+++ b/doc/SECURITY.md
@@ -1,0 +1,7 @@
+<!-- SPDX-License-Identifier: GFDL-1.3-no-invariants-or-later
+     SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation. All rights reserved. -->
+# Security Policy
+Intel is committed to rapidly addressing security vulnerabilities affecting our customers and providing clear guidance on the solution, impact, severity and mitigation.
+
+## Reporting a Vulnerability
+Please report any security vulnerabilities in this project utilizing the guidelines [here](https://www.intel.com/content/www/us/en/security-center/vulnerability-handling-guidelines.html).


### PR DESCRIPTION
This commit refactors the `connect_ptp4l.cpp` file in the clkmgr proxy by simplifying the message handling functions and removing the `combinedList` vector.
These changes improve the code readability and maintainability by reducing the complexity of the message handling logic.

Tested with 2 sample apps with 2 ptp4l and 2 chrony running:
![image](https://github.com/user-attachments/assets/1a310dbc-695a-4ee0-904c-895c71bc8d55)
