### PR TITLE
clkmgr: Add timeBaseIndex handling and parsing in ClkMgrSubscription.

### DIFF
--- a/clkmgr/client/clockmanager.cpp
+++ b/clkmgr/client/clockmanager.cpp
@@ -37,6 +37,9 @@ rtpi::condition_variable ClientConnectMessage::cv;
 rtpi::mutex ClientSubscribeMessage::cv_mtx;
 rtpi::condition_variable ClientSubscribeMessage::cv;
 
+/* Global vector to hold all time base configurations */
+std::vector<TimeBaseCfg> timeBaseCfgs;
+
 ClockManager::ClockManager() : implClientState(new ClientState()) {}
 
 ClockManager::~ClockManager() = default;
@@ -90,8 +93,13 @@ bool ClockManager::clkmgr_connect()
     return true;
 }
 
+std::vector<TimeBaseCfg> ClockManager::clkmgr_get_timebase_cfgs() const
+{
+    return timeBaseCfgs;
+}
+
 bool ClockManager::clkmgr_subscribe(const ClkMgrSubscription &newSub,
-    Event_state &currentState)
+    int timeBaseIndex, Event_state &currentState)
 {
     unsigned int timeout_sec = (unsigned int) DEFAULT_SUBSCRIBE_TIME_OUT;
     PrintDebug("[clkmgr]::subscribe");
@@ -103,6 +111,7 @@ bool ClockManager::clkmgr_subscribe(const ClkMgrSubscription &newSub,
     } else
         PrintDebug("[clkmgr::subscribe] subscribeMsgcreation is OK !!");
     cmsg->setClientState(implClientState.get());
+    cmsg->set_timeBaseIndex(timeBaseIndex);
     /* Write the current event subscription */
     implClientState->set_eventSub(newSub);
     /* Copy the event Mask */

--- a/clkmgr/client/connect_msg.cpp
+++ b/clkmgr/client/connect_msg.cpp
@@ -18,6 +18,7 @@ __CLKMGR_NAMESPACE_USE;
 
 using namespace std;
 
+extern std::vector<TimeBaseCfg> timeBaseCfgs;
 ClientState *ClientConnectMessage::currentClientState = nullptr;
 
 /**
@@ -51,6 +52,15 @@ PARSE_RXBUFFER_TYPE(ClientConnectMessage::parseBuffer)
     PrintDebug("[ClientConnectMessage]::parseBuffer ");
     if(!CommonConnectMessage::parseBuffer(LxContext))
         return false;
+    size_t mapSize = 0;
+    if(!PARSE_RX(FIELD, mapSize, LxContext))
+        return false;
+    for(size_t i = 0; i < mapSize; ++i) {
+        TimeBaseCfg newCfg;
+        if(!PARSE_RX(FIELD, newCfg, LxContext))
+            return false;
+        timeBaseCfgs.push_back(newCfg);
+    }
     return true;
 }
 

--- a/clkmgr/client/subscribe_msg.cpp
+++ b/clkmgr/client/subscribe_msg.cpp
@@ -58,6 +58,16 @@ void ClientSubscribeMessage::setClientState(ClientState *newClientState)
     clkmgrCurrentState = &(newClientState->get_eventState());
 }
 
+BUILD_TXBUFFER_TYPE(ClientSubscribeMessage::makeBuffer) const
+{
+    PrintDebug("[ProxySubscribeMessage]::makeBuffer");
+    if(!CommonSubscribeMessage::makeBuffer(TxContext))
+        return false;
+    if(!WRITE_TX(FIELD, timeBaseIndex, TxContext))
+        return false;
+    return true;
+}
+
 PARSE_RXBUFFER_TYPE(ClientSubscribeMessage::parseBuffer)
 {
     ptp_event data = {};

--- a/clkmgr/client/subscribe_msg.hpp
+++ b/clkmgr/client/subscribe_msg.hpp
@@ -30,6 +30,7 @@ class ClientSubscribeMessage : virtual public
     static ClientState *currentClientState;
     static std::map <sessionId_t, std::array<client_ptp_event *, 2>>
         client_ptp_event_map;
+    int timeBaseIndex; /**< Timebase index */
 
   public:
     ClientSubscribeMessage() : MESSAGE_SUBSCRIBE() {};
@@ -59,6 +60,7 @@ class ClientSubscribeMessage : virtual public
     static bool initMessage();
 
     virtual PARSE_RXBUFFER_TYPE(parseBuffer);
+    virtual BUILD_TXBUFFER_TYPE(makeBuffer) const;
 
     void setClientState(ClientState *newClientState);
 
@@ -72,6 +74,22 @@ class ClientSubscribeMessage : virtual public
 
     /* Reduce the corresponding eventCount */
     static void resetClientPtpEventStruct(sessionId_t sID, Event_count &eventCount);
+
+    /**
+     * Set the time base index.
+     * @param[in] newTimeBaseIndex The new time base index to set.
+     */
+    void set_timeBaseIndex(int newTimeBaseIndex) {
+        timeBaseIndex = newTimeBaseIndex;
+    }
+
+    /**
+     * Get the value of the time base index.
+     * @return The value of the time base index.
+     */
+    int get_timeBaseIndex() const {
+        return timeBaseIndex;
+    }
 };
 
 __CLKMGR_NAMESPACE_END

--- a/clkmgr/proxy/connect_msg.cpp
+++ b/clkmgr/proxy/connect_msg.cpp
@@ -13,6 +13,7 @@
 #include "common/message.hpp"
 #include "common/print.hpp"
 #include "common/serialize.hpp"
+#include "proxy/config_parser.hpp"
 #include "proxy/connect_msg.hpp"
 #include "proxy/client.hpp"
 #include "proxy/subscribe_msg.hpp"
@@ -92,5 +93,13 @@ BUILD_TXBUFFER_TYPE(ProxyConnectMessage::makeBuffer) const
     PrintDebug("[ProxyConnectMessage]::makeBuffer");
     if(!CommonConnectMessage::makeBuffer(TxContext))
         return false;
+    size_t mapSize = timeBaseCfgs.size();
+    if(!WRITE_TX(FIELD, mapSize, TxContext))
+        return false;;
+    for(size_t i = 0; i < mapSize; i++) {
+        TimeBaseCfg cfg = timeBaseCfgs[i];
+        if(!WRITE_TX(FIELD, cfg, TxContext))
+            return false;
+    }
     return true;
 }

--- a/clkmgr/proxy/subscribe_msg.cpp
+++ b/clkmgr/proxy/subscribe_msg.cpp
@@ -23,9 +23,6 @@ __CLKMGR_NAMESPACE_USE;
 using namespace std;
 
 extern std::map<int, ptp_event> ptp4lEvents;
-int timeBaseIndexTest[2] = {2, 1}; // TO BE REMOVED
-int i = 0; // TO BE REMOVED
-int j = 0; // TO BE REMOVED
 
 /**
  * Create the ProxySubscribeMessage object
@@ -58,8 +55,7 @@ BUILD_TXBUFFER_TYPE(ProxySubscribeMessage::makeBuffer) const
     PrintDebug("[ProxySubscribeMessage]::makeBuffer");
     if(!CommonSubscribeMessage::makeBuffer(TxContext))
         return false;
-    ptp_event event = ptp4lEvents[timeBaseIndexTest[j]];
-    j++; // TO BE REMOVED
+    ptp_event event = ptp4lEvents[timeBaseIndex];
     /* Add ptp data here */
     if(!WRITE_TX(FIELD, event, TxContext))
         return false;
@@ -71,10 +67,11 @@ PARSE_RXBUFFER_TYPE(ProxySubscribeMessage::parseBuffer)
     PrintDebug("[ProxySubscribeMessage]::parseBuffer ");
     if(!CommonSubscribeMessage::parseBuffer(LxContext))
         return false;
-    ConnectPtp4l::subscribe_ptp4l(timeBaseIndexTest[i], this->getc_sessionId());
-    i++; // TO BE REMOVED
+    if(!PARSE_RX(FIELD, timeBaseIndex, LxContext))
+        return false;
+    ConnectPtp4l::subscribe_ptp4l(timeBaseIndex, this->getc_sessionId());
     #ifdef HAVE_LIBCHRONY
-    ConnectChrony::subscribe_chrony(std::move(timeBaseIndexTest[i]),
+    ConnectChrony::subscribe_chrony(std::move(timeBaseIndex),
         this->getc_sessionId());
     #endif
     return true;

--- a/clkmgr/proxy/subscribe_msg.hpp
+++ b/clkmgr/proxy/subscribe_msg.hpp
@@ -22,7 +22,7 @@ class ProxySubscribeMessage : virtual public ProxyMessage,
     virtual public CommonSubscribeMessage
 {
   private:
-    //int timeBaseIndex;
+    int timeBaseIndex;
   protected:
     ProxySubscribeMessage() : MESSAGE_SUBSCRIBE() {};
   public:

--- a/clkmgr/pub/clkmgr/clockmanager_c.h
+++ b/clkmgr/pub/clkmgr/clockmanager_c.h
@@ -53,14 +53,32 @@ bool clkmgr_c_connect(clkmgr_c_client_ptr client_ptr);
 bool clkmgr_c_disconnect(clkmgr_c_client_ptr client_ptr);
 
 /**
+ * Get the time base configuration
+ * @param[in, out] client_ptr Pointer to the client instance
+ * @param[in] time_base_index Index of the time base to be retrieved
+ * @param[out] cfg Pointer to the TimeBaseCfg structures
+ * @return true on success, false on failure
+ */
+bool clkmgr_c_get_timebase_cfgs(clkmgr_c_client_ptr client_ptr,
+    int time_base_index, struct Clkmgr_TimeBaseCfg *cfg);
+
+/**
+ * Get the size of the time base configurations
+ * @param[in, out] client_ptr Pointer to the client instance
+ * @return The size of the time base configurations
+ */
+size_t clkmgr_c_get_timebase_cfgs_size(clkmgr_c_client_ptr client_ptr);
+
+/**
  * Subscribe to client events
  * @param[in, out] client_ptr Pointer to the client instance
  * @param[in] sub Subscription structure
+ * @param[in] time_base_index Index of the time base to be subscribed
  * @param[out] current_state Pointer to the current state structure
  * @return true on success, false on failure
  */
 bool clkmgr_c_subscribe(clkmgr_c_client_ptr client_ptr,
-    const struct clkmgr_c_subscription sub,
+    const struct clkmgr_c_subscription sub, int time_base_index,
     struct Clkmgr_Event_state *current_state);
 
 /**

--- a/clkmgr/pub/clockmanager.h
+++ b/clkmgr/pub/clockmanager.h
@@ -16,6 +16,7 @@
 
 #include "pub/clkmgr/subscription.h"
 #include <memory>
+#include <vector>
 
 __CLKMGR_NAMESPACE_BEGIN
 
@@ -70,12 +71,19 @@ class ClockManager
     bool clkmgr_disconnect();
 
     /**
+     * Get the time base configurations
+     * @return vector of TimeBaseCfg
+     */
+    std::vector<TimeBaseCfg> clkmgr_get_timebase_cfgs() const;
+
+    /**
      * Subscribe to events
      * @param[in] newSub Reference to the new subscription
+     * @param[in] timeBaseIndex Index of the time base to be subscribed
      * @param[out] currentState Reference to the current state
      * @return true on success, false on failure
      */
-    bool clkmgr_subscribe(const ClkMgrSubscription &newSub,
+    bool clkmgr_subscribe(const ClkMgrSubscription &newSub, int timeBaseIndex,
         Event_state &currentState);
 
     /**

--- a/clkmgr/sample/clkmgr_c_test.c
+++ b/clkmgr/sample/clkmgr_c_test.c
@@ -166,7 +166,31 @@ int main(int argc, char *argv[])
 
     sleep(1);
 
-    if (clkmgr_c_subscribe(client_ptr, subscription, &event_state) == false) {
+    size_t index_size = clkmgr_c_get_timebase_cfgs_size(client_ptr);
+    if(index_size == 0) {
+        printf("[clkmgr] No available clock found !!!\n");
+        ret = EXIT_FAILURE;
+        goto do_exit;
+    }
+    printf("[clkmgr] List of available clock: \n");
+    for(size_t i = 1; i <= index_size; i++) {
+        struct Clkmgr_TimeBaseCfg cfg;
+        if (clkmgr_c_get_timebase_cfgs(client_ptr, i, &cfg)) {
+            printf("TimeBaseIndex: %d\n", cfg.timeBaseIndex);
+            printf("timeBaseName: %s\n", cfg.timeBaseName);
+            printf("udsAddrChrony: %s\n", cfg.udsAddrChrony);
+            printf("udsAddrPtp4l: %s\n", cfg.udsAddrPtp4l);
+            printf("interfaceName: %s\n", cfg.interfaceName);
+            printf("transportSpecific: %d\n", cfg.transportSpecific);
+            printf("domainNumber: %d\n\n", cfg.domainNumber);
+        } else {
+            printf("Failed to get time base configuration for index %d\n", i);
+        }
+    }
+
+    /* Subscribe to default time base index 1 */
+    printf("[clkmgr] Subscribe to time base index 1. \n");
+    if (clkmgr_c_subscribe(client_ptr, subscription, 1, &event_state) == false) {
         printf("[clkmgr] Failure in subscribing to clkmgr Proxy !!!\n");
         ret = EXIT_FAILURE;
         goto do_exit;

--- a/clkmgr/sample/clkmgr_test.cpp
+++ b/clkmgr/sample/clkmgr_test.cpp
@@ -186,8 +186,20 @@ int main(int argc, char *argv[])
     std::cout << "GM Offset lower limit: " << std::dec << gmOffsetLowerLimit << " ns\n";
     std::cout << "Chrony Offset upper limit: " << std::dec << chronyGmOffsetUpperLimit << " ns\n";
     std::cout << "Chrony Offset lower limit: " << std::dec << chronyGmOffsetLowerLimit << " ns\n\n";
-
-    if (!cm.clkmgr_subscribe(subscription, eventState)) {
+    std::cout << "[clkmgr] List of available clock: \n";
+    /* Print out each member of the TimeBaseCfg objects */
+    for (const auto &cfg : cm.clkmgr_get_timebase_cfgs()) {
+        std::cout << "TimeBaseIndex: " << cfg.timeBaseIndex << "\n";
+        std::cout << "timeBaseName: " << cfg.timeBaseName << "\n";
+        std::cout << "udsAddrChrony: " << cfg.udsAddrChrony << "\n";
+        std::cout << "udsAddrPtp4l: " << cfg.udsAddrPtp4l << "\n";
+        std::cout << "interfaceName: " << cfg.interfaceName << "\n";
+        std::cout << "transportSpecific: " << static_cast<int>(cfg.transportSpecific) << "\n";
+        std::cout << "domainNumber: " << static_cast<int>(cfg.domainNumber) << "\n\n";
+    }
+    /* Subscribe to default time base index 1 */
+    std::cout << "[clkmgr] Subscribe to time base index 1. \n\n";
+    if (!cm.clkmgr_subscribe(subscription, 1, eventState)) {
         std::cerr << "[clkmgr] Failure in subscribing to clkmgr Proxy !!!\n";
         cm.clkmgr_disconnect();
         return EXIT_FAILURE;


### PR DESCRIPTION
This commit introduces the handling and parsing of the timeBaseIndex in the ClkMgrSubscription class.
- Added timeBaseIndex member to ClkMgrSubscription class.
- Implemented getter and setter methods for timeBaseIndex in ClkMgrSubscription.
- Updated ClockManager::clkmgr_subscribe to accept and set timeBaseIndex.
- Modified ClientSubscribeMessage and CommonSubscribeMessage to handle timeBaseIndex.
- Updated the parsing and serialization logic in connect_msg.cpp and subscribe_msg.cpp to include timeBaseIndex.
- Adjusted the clkmgr_test.cpp to use the new clkmgr_subscribe method with timeBaseIndex.

Tested with 2 sample apps each subscribe to one domain of ptp4l.
1. Subscription: 
![image](https://github.com/user-attachments/assets/79ba6698-590b-4e3f-b814-112400535bc1)

2. Notification:
![image](https://github.com/user-attachments/assets/2f9b48f2-ddc3-4461-ba8f-1d58b2b69b31)


