### PR TITLE
clkmgr: Add unsubscibe session id functionality for ptp4l and chrony

### DIFF
--- a/clkmgr/proxy/connect_chrony.hpp
+++ b/clkmgr/proxy/connect_chrony.hpp
@@ -19,6 +19,7 @@ class ConnectChrony
   public:
     static void connect_chrony();
     static int subscribe_chrony(int timeBaseIndex, sessionId_t sessionId);
+    static int remove_chrony_subscriber(int timeBaseIndex, sessionId_t sessionId);
 };
 
 __CLKMGR_NAMESPACE_END

--- a/clkmgr/proxy/connect_ptp4l.hpp
+++ b/clkmgr/proxy/connect_ptp4l.hpp
@@ -22,6 +22,7 @@ class ConnectPtp4l
   public:
     static int connect_ptp4l();
     static int subscribe_ptp4l(int timeBaseIndex, sessionId_t sessionId);
+    static int remove_ptp4l_subscriber(int timeBaseIndex, sessionId_t sessionId);
     static void disconnect_ptp4l();
 };
 


### PR DESCRIPTION
These changes ensure that the session IDs are properly removed from the subscribed clients list when a message transmission fails, improving the robustness of the sample applications.