### PR TITLE
clkmgr: Fix typo on config_parser and JSON file

### DIFF
--- a/clkmgr/proxy/config_parser.cpp
+++ b/clkmgr/proxy/config_parser.cpp
@@ -82,7 +82,7 @@ bool JsonConfigParser::process_json(const char *file)
     int currentIndex = 1;
     if(!main.parseFile(file, true))
         return false;
-    timeBaseArray = main.getObj()->getArr("timeBase");
+    timeBaseArray = main.getObj()->getArr("timeBases");
     if(!timeBaseArray)
         return false;
     for(size_t idx = 0; idx < timeBaseArray->size(); ++idx) {

--- a/clkmgr/proxy/proxy_cfg.json
+++ b/clkmgr/proxy/proxy_cfg.json
@@ -9,7 +9,7 @@
  *
  */
 {
-    "timeBase": [
+    "timeBases": [
         {
             "timeBaseName": "Global Clock",
             "ptp4l":


### PR DESCRIPTION
Fix typo for timeBase to timeBases on config_parser and JSON file

Proxy:
<img width="770" alt="image" src="https://github.com/user-attachments/assets/d0ad1f6e-79f9-492a-8703-931d74dff494" />

Sample App:
<img width="645" alt="image" src="https://github.com/user-attachments/assets/c408b54f-f25b-4e43-8d63-0466f1bb2c4a" />
