### PR TITLE
clkmgr: Move utility definitions from pub to common.

### DIFF
--- a/clkmgr/client/client_state.hpp
+++ b/clkmgr/client/client_state.hpp
@@ -12,6 +12,7 @@
 #ifndef CLIENT_CLIENT_STATE_H
 #define CLIENT_CLIENT_STATE_H
 
+#include "common/util.hpp"
 #include "pub/clkmgr/subscription.h"
 
 #include <string>

--- a/clkmgr/common/util.hpp
+++ b/clkmgr/common/util.hpp
@@ -14,6 +14,20 @@
 
 #include "pub/clkmgr/utility.h"
 
+__CLKMGR_NAMESPACE_BEGIN
+
+/** Maximum number of character for transport client ID */
+const int TRANSPORT_CLIENTID_LENGTH = 512;
+
+/** Array to store transport client ID. */
+typedef std::array<uint8_t, TRANSPORT_CLIENTID_LENGTH> TransportClientId;
+
+/** Type definition for session ID. */
+typedef uint16_t sessionId_t;
+
+/** Invalid session ID (default session ID) */
+const sessionId_t InvalidSessionId = UINT16_MAX;
+
 /* Some commonly used constants */
 #define NSEC_PER_MSEC   (1000000)
 #define NSEC_PER_SEC    (1000000000)
@@ -29,5 +43,7 @@
             return retval;                  \
         }                           \
     }
+
+__CLKMGR_NAMESPACE_END
 
 #endif /* UTIL_HPP */

--- a/clkmgr/pub/clkmgr/utility.h
+++ b/clkmgr/pub/clkmgr/utility.h
@@ -24,20 +24,4 @@
 #define __CLKMGR_NAMESPACE_END }
 #endif
 
-__CLKMGR_NAMESPACE_BEGIN
-
-/** Maximum number of character for transport client ID */
-const int TRANSPORT_CLIENTID_LENGTH = 512;
-
-/** Array to store transport client ID. */
-typedef std::array<uint8_t, TRANSPORT_CLIENTID_LENGTH> TransportClientId;
-
-/** Type definition for session ID. */
-typedef uint16_t sessionId_t;
-
-/** Invalid session ID (default session ID) */
-const sessionId_t InvalidSessionId = UINT16_MAX;
-
-__CLKMGR_NAMESPACE_END
-
 #endif /* CLKMGR_UTILITY_H */


### PR DESCRIPTION
Moved the definitions of TRANSPORT_CLIENTID_LENGTH, TransportClientId, sessionId_t, and InvalidSessionId from clkmgr/pub/clkmgr/utility.h to clkmgr/common/util.hpp, because these parameters are transparent to user application.