### PR TITLE
clkmgr Refactor chrony connection handling and improve reconnection logic

### DIFF
--- a/clkmgr/proxy/connect_ptp4l.cpp
+++ b/clkmgr/proxy/connect_ptp4l.cpp
@@ -318,7 +318,7 @@ void ptpSet::thread_loop()
                     notify_client();
                 }
                 PrintInfo("Attempting to reconnect to ptp4l at " + udsAddr);
-                sleep(2);
+                sleep(5);
             }
             if(lost_connection) {
                 PrintInfo("Reconnected to ptp4l at " + udsAddr);


### PR DESCRIPTION
- Updated the monitor_chronyd function to use the udsAddrChrony from ThreadArgs for reconnection attempts.
- Simplified the reconnection logic by refactoring it into a separate function.

chrony data is reset if chronyd is terminated:
![image](https://github.com/user-attachments/assets/79ba45ef-ba5c-4e10-8f11-66d748e36023)

proxy able reconnect to chronyd again and able to get the chrony data:
![image](https://github.com/user-attachments/assets/c459fd9b-0a94-48a8-ad5b-f50d16abd92f)

clkmgr manage to connect to chronyd if chronyd is run after proxy (flow: start proxy -> sample apps -> chronyd)
![image](https://github.com/user-attachments/assets/6702a8a9-8d45-4dc7-9170-c7f7a2dfac66)
