### PR TITLE
clkmgr:Add support for subscribing to time base by name.

### DIFF
--- a/clkmgr/client/clockmanager.cpp
+++ b/clkmgr/client/clockmanager.cpp
@@ -98,6 +98,21 @@ std::vector<TimeBaseCfg> ClockManager::clkmgr_get_timebase_cfgs() const
     return TimeBaseConfigurations::getInstance().getTimeBaseCfgs();
 }
 
+bool ClockManager::clkmgr_subscribe_by_name(const ClkMgrSubscription &newSub,
+    char timeBaseName[STRING_SIZE_MAX], Event_state &currentState)
+{
+    int timeBaseIndex = -1;
+    for(const auto &cfg : ClockManager::clkmgr_get_timebase_cfgs()) {
+        if(strcmp(cfg.timeBaseName, timeBaseName) == 0)
+            timeBaseIndex = cfg.timeBaseIndex;
+    }
+    if(timeBaseIndex == -1) {
+        PrintDebug("[SUBSCRIBE] Invalid timeBaseName.");
+        return false;
+    }
+    return clkmgr_subscribe(newSub, timeBaseIndex, currentState);
+}
+
 bool ClockManager::clkmgr_subscribe(const ClkMgrSubscription &newSub,
     int timeBaseIndex, Event_state &currentState)
 {
@@ -220,6 +235,22 @@ send_connect:
             PrintDebug("[CONNECT] Received reply from Proxy.");
     }
     return true;
+}
+
+int ClockManager::clkmgr_status_wait_by_name(int timeout,
+    char timeBaseName[STRING_SIZE_MAX],
+    Event_state &currentState, Event_count &currentCount)
+{
+    int timeBaseIndex = -1;
+    for(const auto &cfg : ClockManager::clkmgr_get_timebase_cfgs()) {
+        if(strcmp(cfg.timeBaseName, timeBaseName) == 0)
+            timeBaseIndex = cfg.timeBaseIndex;
+    }
+    if(timeBaseIndex == -1) {
+        PrintDebug("[SUBSCRIBE] Invalid timeBaseName.");
+        return -1;
+    }
+    return clkmgr_status_wait(timeout, timeBaseIndex, currentState, currentCount);
 }
 
 int ClockManager::clkmgr_status_wait(int timeout, int timeBaseIndex,

--- a/clkmgr/client/clockmanager_c.cpp
+++ b/clkmgr/client/clockmanager_c.cpp
@@ -65,6 +65,27 @@ size_t clkmgr_c_get_timebase_cfgs_size(clkmgr_c_client_ptr client_ptr)
     return cm->clkmgr_get_timebase_cfgs().size();
 }
 
+bool clkmgr_c_subscribe_by_name(clkmgr_c_client_ptr client_ptr,
+    const clkmgr_c_subscription sub, char timeBaseName[CLKMGR_STRING_SIZE_MAX],
+    Clkmgr_Event_state *current_state)
+{
+    if(client_ptr == nullptr || timeBaseName == nullptr ||
+        current_state == nullptr)
+        return false;
+    clkmgr::ClockManager *cm = static_cast<clkmgr::ClockManager *>(client_ptr);
+    int timeBaseIndex = -1;
+    std::vector<clkmgr::TimeBaseCfg> cfgs = cm->clkmgr_get_timebase_cfgs();
+    for(const auto &cfg : cfgs) {
+        if(strncmp(cfg.timeBaseName, timeBaseName, CLKMGR_STRING_SIZE_MAX) == 0) {
+            timeBaseIndex = cfg.timeBaseIndex;
+            break;
+        }
+    }
+    if(timeBaseIndex == -1)
+        return false;
+    return clkmgr_c_subscribe(client_ptr, sub, timeBaseIndex, current_state);
+}
+
 bool clkmgr_c_subscribe(clkmgr_c_client_ptr client_ptr,
     const clkmgr_c_subscription sub, int time_base_index,
     Clkmgr_Event_state *current_state)
@@ -100,6 +121,28 @@ bool clkmgr_c_subscribe(clkmgr_c_client_ptr client_ptr,
         current_state->polling_interval = state.polling_interval;
     }
     return ret;
+}
+
+int clkmgr_c_status_wait_by_name(clkmgr_c_client_ptr client_ptr, int timeout,
+    char timeBaseName[CLKMGR_STRING_SIZE_MAX], Clkmgr_Event_state *current_state,
+    Clkmgr_Event_count *current_count)
+{
+    if(client_ptr == nullptr || timeBaseName == nullptr ||
+        current_state == nullptr)
+        return -1;
+    clkmgr::ClockManager *cm = static_cast<clkmgr::ClockManager *>(client_ptr);
+    int timeBaseIndex = -1;
+    std::vector<clkmgr::TimeBaseCfg> cfgs = cm->clkmgr_get_timebase_cfgs();
+    for(const auto &cfg : cfgs) {
+        if(strncmp(cfg.timeBaseName, timeBaseName, CLKMGR_STRING_SIZE_MAX) == 0) {
+            timeBaseIndex = cfg.timeBaseIndex;
+            break;
+        }
+    }
+    if(timeBaseIndex == -1)
+        return -1;
+    return clkmgr_c_status_wait(client_ptr, timeout, timeBaseIndex, current_state,
+            current_count);
 }
 
 int clkmgr_c_status_wait(clkmgr_c_client_ptr client_ptr, int timeout,

--- a/clkmgr/pub/clkmgr/clockmanager_c.h
+++ b/clkmgr/pub/clkmgr/clockmanager_c.h
@@ -70,6 +70,19 @@ bool clkmgr_c_get_timebase_cfgs(clkmgr_c_client_ptr client_ptr,
 size_t clkmgr_c_get_timebase_cfgs_size(clkmgr_c_client_ptr client_ptr);
 
 /**
+ * Subscribe to client events by name for the time base
+ * @param[in, out] client_ptr Pointer to the client instance
+ * @param[in] sub Subscription structure
+ * @param[in] timeBaseName Name of the time base to be subscribed
+ * @param[out] current_state Pointer to the current state structure
+ * @return true on success, false on failure
+ */
+bool clkmgr_c_subscribe_by_name(clkmgr_c_client_ptr client_ptr,
+    const struct clkmgr_c_subscription sub,
+    char timeBaseName[CLKMGR_STRING_SIZE_MAX],
+    struct Clkmgr_Event_state *current_state);
+
+/**
  * Subscribe to client events
  * @param[in, out] client_ptr Pointer to the client instance
  * @param[in] sub Subscription structure
@@ -80,6 +93,24 @@ size_t clkmgr_c_get_timebase_cfgs_size(clkmgr_c_client_ptr client_ptr);
 bool clkmgr_c_subscribe(clkmgr_c_client_ptr client_ptr,
     const struct clkmgr_c_subscription sub, int time_base_index,
     struct Clkmgr_Event_state *current_state);
+
+/**
+ * Waits for a specified timeout period for any event changes by name of the
+ * time base
+ * @param[in, out] client_ptr Pointer to the client instance
+ * @param[in] timeout TThe timeout in seconds. If timeout is 0, the function
+ * will check event changes once. If timeout is -1, the function will wait
+ * until there is event changes occurs
+ * @param[in] timeBaseName Name of the time base to be monitored
+ * @param[out] current_state Pointer to the current state structure
+ * @param[out] current_count Pointer to the event count structure
+ * @return true if there is event changes within the timeout period,
+ *         and false otherwise
+ */
+int clkmgr_c_status_wait_by_name(clkmgr_c_client_ptr client_ptr, int timeout,
+    char timeBaseName[CLKMGR_STRING_SIZE_MAX],
+    struct Clkmgr_Event_state *current_state,
+    struct Clkmgr_Event_count *current_count);
 
 /**
  * Waits for a specified timeout period for any event changes

--- a/clkmgr/pub/clockmanager.h
+++ b/clkmgr/pub/clockmanager.h
@@ -77,6 +77,16 @@ class ClockManager
     std::vector<TimeBaseCfg> clkmgr_get_timebase_cfgs() const;
 
     /**
+     * Subscribe to events by name of the time base
+     * @param[in] newSub Reference to the new subscription
+     * @param[in] timeBaseName Name of the time base to be subscribed
+     * @param[out] currentState Reference to the current state
+     * @return true on success, false on failure
+     */
+    bool clkmgr_subscribe_by_name(const ClkMgrSubscription &newSub,
+        char timeBaseName[STRING_SIZE_MAX], Event_state &currentState);
+
+    /**
      * Subscribe to events
      * @param[in] newSub Reference to the new subscription
      * @param[in] timeBaseIndex Index of the time base to be subscribed
@@ -85,6 +95,23 @@ class ClockManager
      */
     bool clkmgr_subscribe(const ClkMgrSubscription &newSub, int timeBaseIndex,
         Event_state &currentState);
+
+    /**
+     * Waits for a specified timeout period for any event changes by
+     * name of the time base.
+     * @param[in] timeout in seconds
+     * @li Use 0 to check without waiting
+     * @li Use -1 to wait until there is event changes occurs.
+     * @param[in] timeBaseName Name of the time base to be monitored
+     * @param[out] currentState Reference to the current event state
+     * @param[out] currentCount Reference to the current event count
+     * @return result
+     * @li 1 when an event changes within the timeout period
+     * @li 0 No event changes
+     * @li -1 lost connection to the Clock manager Proxy
+     */
+    int clkmgr_status_wait_by_name(int timeout, char timeBaseName[STRING_SIZE_MAX],
+        Event_state &currentState, Event_count &currentCount);
 
     /**
      * Waits for a specified timeout period for any event changes.


### PR DESCRIPTION
This patch introduces the ability to subscribe to time base events using the time base name instead of the index. The following changes have been made:

- Added `clkmgr_subscribe_by_name` and `clkmgr_status_wait_by_name` methods to the `ClockManager` class.
- Implemented corresponding C functions `clkmgr_c_subscribe_by_name` and `clkmgr_c_status_wait_by_name`.

These changes enhance the flexibility of the clock manager by allowing users to monitor time bases by name, making the interface more user-friendly.

C++:
<img width="585" alt="image" src="https://github.com/user-attachments/assets/806581fe-0e4b-4788-be19-3dbc734222c3" />

C:
<img width="599" alt="image" src="https://github.com/user-attachments/assets/19cb61ed-ddab-4c5a-b111-c7f1ef8c1c51" />
