### PR TITLE
Fix gm_changed event status and coverity issue

### DIFF
--- a/clkmgr/client/timebase_state.cpp
+++ b/clkmgr/client/timebase_state.cpp
@@ -101,6 +101,7 @@ bool TimeBaseStates::getTimeBaseState(int timeBaseIndex, TimeBaseState &state)
         state = it->second; // Copy the TimeBaseState object
         it->second.set_eventStateCount({}); // reset eventStateCount
         it->second.set_event_changed(false); // reset event_changed
+        it->second.get_eventState().gm_changed = false; // reset gm_changed
         return true;
     }
     // If timeBaseIndex is not found, return false
@@ -161,8 +162,7 @@ void TimeBaseStates::setTimeBaseState(int timeBaseIndex,
         eventState.gm_changed = true;
         eventCount.gm_changed_event_count++;
         state.set_event_changed(true);
-    } else
-        eventState.gm_changed = false;
+    }
     // Update eventASCapable
     if((eventSub & eventASCapable) &&
         (newEvent.as_capable != eventState.as_capable)) {

--- a/clkmgr/proxy/config_parser.cpp
+++ b/clkmgr/proxy/config_parser.cpp
@@ -124,7 +124,7 @@ bool JsonConfigParser::process_json(const char *file)
         }
         config.timeBaseIndex = currentIndex;
         currentIndex++;
-        timeBaseCfgs.push_back(row);
+        timeBaseCfgs.push_back(std::move(row));
     }
     print_config();
     return true;

--- a/clkmgr/proxy/connect_ptp4l.cpp
+++ b/clkmgr/proxy/connect_ptp4l.cpp
@@ -71,7 +71,7 @@ class ptpSet : MessageDispatcher
   public:
     // These methods are used during initializing, before we create the thread.
     ptpSet(const TimeBaseCfg &p, string uds) : timeBaseIndex(p.timeBaseIndex),
-        param(p), event(ptp4lEvents[p.timeBaseIndex]), udsAddr(uds) {}
+        param(p), event(ptp4lEvents[p.timeBaseIndex]), udsAddr(std::move(uds)) {}
     bool init();
     void close() { sku.close(); }
     void start();


### PR DESCRIPTION
Tested gm_changed status is updated as expected when gm is disconnected and restart again:
![image](https://github.com/user-attachments/assets/c0cc5d46-12ed-4fd7-aa47-86355198cfac)

Jira ticket: https://jira.devtools.intel.com/browse/IOTGREALTJ-255
