### PR TITLE
clkmgr: replace the use of move with constant reference.

### DIFF
--- a/clkmgr/proxy/connect_ptp4l.cpp
+++ b/clkmgr/proxy/connect_ptp4l.cpp
@@ -60,7 +60,7 @@ class ptpSet : MessageDispatcher
     int timeBaseIndex; // Index of the time base
     const TimeBaseCfg &param; // time base configuration
     ptp_event &event;
-    string udsAddr;
+    const string &udsAddr;
     ptpmgmt::Message msg;
     SockUnix sku;
     bool do_notify = false;
@@ -70,8 +70,9 @@ class ptpSet : MessageDispatcher
     vector<sessionId_t> subscribedClients; // Clients list for notification
   public:
     // These methods are used during initializing, before we create the thread.
-    ptpSet(const TimeBaseCfg &p, string uds) : timeBaseIndex(p.timeBaseIndex),
-        param(p), event(ptp4lEvents[p.timeBaseIndex]), udsAddr(std::move(uds)) {}
+    ptpSet(const TimeBaseCfg &p, const string &uds) :
+        timeBaseIndex(p.timeBaseIndex), param(p),
+        event(ptp4lEvents[p.timeBaseIndex]), udsAddr(uds) {}
     bool init();
     void close() { sku.close(); }
     void start();


### PR DESCRIPTION
Using constant reference as function parameter allow
 calling with r-value, but do not copy,
 though eliminate the need to move.

In class ptpSet in connect_ptp4l.cpp,
 convert udsAddr to reference, so we skip 1 copy and 1 move.

Tested working as expected:
![image](https://github.com/user-attachments/assets/02667811-8413-4fd0-96bb-24f35f76e9c3)
