### PR TITLE
clkmgr: Improve proxy liveness check with last connect time tracking.

### DIFF
--- a/clkmgr/TEST_clkmgr.md
+++ b/clkmgr/TEST_clkmgr.md
@@ -209,7 +209,7 @@ Options:
  -v <0|1> Enable or disable verbose output
           0: disable, 1: enable(default)
  -s <0|1> Enable or disable system log printing
-          0: disable, 1: enable(default)
+          0: disable(default), 1: enable
  -h       Show this help message
 ```
 

--- a/clkmgr/proxy/main.cpp
+++ b/clkmgr/proxy/main.cpp
@@ -29,7 +29,7 @@ using namespace std;
 int main(int argc, char *argv[])
 {
     int level, verbose, syslog;
-    bool startSyslog = true;
+    bool startSyslog = false;
     bool getJsonConfig = false;
     int opt;
     const char *file = nullptr;
@@ -77,7 +77,7 @@ int main(int argc, char *argv[])
                     " -v <0|1> Enable or disable verbose output\n"
                     "          0: disable, 1: enable(default)\n"
                     " -s <0|1> Enable or disable system log printing\n"
-                    "          0: disable, 1: enable(default)\n"
+                    "          0: disable(default), 1: enable\n"
                     " -h       Show this help message\n",
                     argv[0]);
                 return EXIT_SUCCESS;
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
                     " -v <0|1> Enable or disable verbose output\n"
                     "          0: disable, 1: enable(default)\n"
                     " -s <0|1> Enable or disable system log printing\n"
-                    "          0: disable, 1: enable(default)\n"
+                    "          0: disable(default), 1: enable\n"
                     " -h       Show this help message\n",
                     argv[0]);
                 return EXIT_FAILURE;

--- a/clkmgr/proxy/run_proxy.sh
+++ b/clkmgr/proxy/run_proxy.sh
@@ -11,4 +11,4 @@ SCRIPT_PATH="$(dirname "$0")"
 TEST_PATH="${SCRIPT_PATH}/../../.libs"
 JSON_FILE="${SCRIPT_PATH}/proxy_cfg.json"
 
-LD_LIBRARY_PATH=$TEST_PATH $SCRIPT_PATH/clkmgr_proxy "$@" -f $JSON_FILE
+LD_LIBRARY_PATH=$TEST_PATH chrt -f 99 $SCRIPT_PATH/clkmgr_proxy "$@" -f $JSON_FILE


### PR DESCRIPTION
This patch enhances the `check_proxy_liveness` function by introducing a static `lastConnectTime` variable to track the last successful connection time.

- Added a check to compare the time elapsed since the last connection with the default liveness timeout.
- Updated the logic to store the last connection time using `clock_gettime` upon receiving a reply from the proxy.