### PR TITLE
clkmgr: Add support for retrieve logSyncInterval from ptp4l.

### DIFF
--- a/clkmgr/client/clockmanager.cpp
+++ b/clkmgr/client/clockmanager.cpp
@@ -25,7 +25,7 @@
 #include <rtpi/condition_variable.hpp>
 #include <rtpi/mutex.hpp>
 
-#define DEFAULT_LIVENESS_TIMEOUT_IN_MS 50  //50 ms
+#define DEFAULT_LIVENESS_TIMEOUT_IN_MS 200  //200 ms
 #define DEFAULT_CONNECT_TIME_OUT 5  //5 sec
 #define DEFAULT_SUBSCRIBE_TIME_OUT 5  //5 sec
 
@@ -264,11 +264,6 @@ int ClockManager::status_wait(int timeout, size_t timeBaseIndex,
     bool event_changes_detected = false;
     TimeBaseState state;
     do {
-        // Check liveness of the Proxy Daemon
-        if(!check_proxy_liveness(timeBaseIndex)) {
-            PrintDebug("[WAIT] Proxy Daemon is not alive.");
-            return -1;
-        }
         // Get the current state of the timebase
         if(!states.getTimeBaseState(timeBaseIndex, state)) {
             PrintDebug("[WAIT] Failed to get specific timebase state.");
@@ -278,6 +273,11 @@ int ClockManager::status_wait(int timeout, size_t timeBaseIndex,
         if(state.is_event_changed()) {
             event_changes_detected = true;
             break;
+        }
+        // Check liveness of the Proxy Daemon
+        if(!check_proxy_liveness(timeBaseIndex)) {
+            PrintDebug("[WAIT] Proxy Daemon is not alive.");
+            return -1;
         }
         // Sleep for a short duration before the next iteration
         this_thread::sleep_for(milliseconds(10));

--- a/clkmgr/client/clockmanager_c.cpp
+++ b/clkmgr/client/clockmanager_c.cpp
@@ -68,6 +68,7 @@ bool clkmgr_subscribe(const clkmgr_c_subscription sub, size_t time_base_index,
         cur_stat->notification_timestamp = state.notification_timestamp;
         std::copy(std::begin(state.gm_identity), std::end(state.gm_identity),
             std::begin(cur_stat->gm_identity));
+        cur_stat->ptp4l_sync_interval = state.ptp4l_sync_interval;
         cur_stat->chrony_clock_offset = state.chrony_clock_offset;
         cur_stat->chrony_reference_id = state.chrony_reference_id;
         cur_stat->chrony_offset_in_range = state.chrony_offset_in_range;
@@ -107,6 +108,7 @@ int clkmgr_status_wait(int timeout, size_t time_base_index,
     cur_stat->notification_timestamp = state.notification_timestamp;
     std::copy(std::begin(state.gm_identity), std::end(state.gm_identity),
         std::begin(cur_stat->gm_identity));
+    cur_stat->ptp4l_sync_interval = state.ptp4l_sync_interval;
     cur_stat->chrony_clock_offset = state.chrony_clock_offset;
     cur_stat->chrony_reference_id = state.chrony_reference_id;
     cur_stat->chrony_offset_in_range = state.chrony_offset_in_range;

--- a/clkmgr/client/timebase_state.cpp
+++ b/clkmgr/client/timebase_state.cpp
@@ -188,6 +188,8 @@ void TimeBaseStates::setTimeBaseState(int timeBaseIndex,
     eventState.notification_timestamp = last_notification_time.tv_sec;
     eventState.notification_timestamp *= NSEC_PER_SEC;
     eventState.notification_timestamp += last_notification_time.tv_nsec;
+    // Update GM logSyncInterval
+    eventState.ptp4l_sync_interval = newEvent.ptp4l_sync_interval;
     // Update Chrony clock offset
     if(newEvent.chrony_offset != eventState.chrony_clock_offset) {
         eventState.chrony_clock_offset = newEvent.chrony_offset;

--- a/clkmgr/common/ptp_event.hpp
+++ b/clkmgr/common/ptp_event.hpp
@@ -23,6 +23,7 @@ struct ptp_event {
     int64_t master_offset;
     uint8_t gm_identity[8]; /* Grandmaster clock ID */
     bool as_capable; /* 802@.1AS Capable */
+    int64_t ptp4l_sync_interval;
     bool synced_to_primary_clock;
     int64_t chrony_offset;
     uint32_t chrony_reference_id;

--- a/clkmgr/common/types.m4
+++ b/clkmgr/common/types.m4
@@ -75,6 +75,7 @@ struct Nm(Event_state) {
     uint64_t notification_timestamp; /**< Timestamp for last notification */
     int64_t clock_offset; /**< Clock offset */
     uint8_t gm_identity[8]; /**< Primary clock UUID */
+    int64_t ptp4l_sync_interval; /**< Clock Sync Interval */
     bool offset_in_range; /**< Clock offset in range */
     bool synced_to_primary_clock; /**< Synced to primary clock */
     bool as_capable; /**< IEEE 802.1AS capable */

--- a/clkmgr/sample/clkmgr_c_test.c
+++ b/clkmgr/sample/clkmgr_c_test.c
@@ -277,6 +277,8 @@ int main(int argc, char *argv[])
                 "clock_offset", event_state.clock_offset);
         printf("| %-25s | %-19ld ns |\n",
                 "notification_timestamp", event_state.notification_timestamp);
+        printf("| %-25s | %-19ld us |\n",
+                "gm_sync_interval", event_state.ptp4l_sync_interval);
         printf("+---------------------------+------------------------+\n");
         if (subscription.composite_event_mask) {
             printf("| %-25s | %-22d |\n", "composite_event",
@@ -369,6 +371,8 @@ int main(int argc, char *argv[])
                 "clock_offset", event_state.clock_offset);
             printf("| %-25s |     %-19ld ns |\n",
                 "notification_timestamp", event_state.notification_timestamp);
+            printf("| %-25s |     %-19ld us |\n",
+                "gm_sync_interval", event_state.ptp4l_sync_interval);
             printf("+---------------------------+--------------+-------------+\n");
             if (subscription.composite_event_mask) {
                 printf("| %-25s | %-12d | %-11d |\n", "composite_event",

--- a/clkmgr/sample/clkmgr_test.cpp
+++ b/clkmgr/sample/clkmgr_test.cpp
@@ -285,6 +285,8 @@ int main(int argc, char *argv[])
                 "clock_offset", eventState.clock_offset);
         printf("| %-25s | %-19ld ns |\n",
                 "notification_timestamp", eventState.notification_timestamp);
+        printf("| %-25s | %-19ld us |\n",
+                "gm_sync_interval", eventState.ptp4l_sync_interval);
         printf("+---------------------------+------------------------+\n");
         if (composite_event) {
             printf("| %-25s | %-22d |\n", "composite_event",
@@ -377,6 +379,8 @@ int main(int argc, char *argv[])
                 "clock_offset", eventState.clock_offset);
             printf("| %-25s |     %-19ld ns |\n",
                 "notification_timestamp", eventState.notification_timestamp);
+            printf("| %-25s |     %-19ld us |\n",
+                "gm_sync_interval", eventState.ptp4l_sync_interval);
             printf("+---------------------------+--------------+-------------+\n");
             if (composite_event) {
                 printf("| %-25s | %-12d | %-11d |\n", "composite_event",


### PR DESCRIPTION
This patch introduces functionality to retrieve the `logSyncInterval` from the
ptp4l daemon and display it in the clkmgr system. The changes include:

    - Remove `PORT_PROPERTIES_NP`.
    - Modified the `PORT_DATA_SET` callback to handle different event.
    - `logSyncInterval` is retrieved from ptp4l daemon and stored in the `event`
      structure.
    - Introduce reset_PortDataSet() to consolidate all the action to reset
      the related port data.
    - Modified the test application to display the `gm_logSyncInterval`

These changes improve the visibility of the Grandmaster's `logSyncInterval`
so that the behavior is transparent and controllable in the clkmgr system.