### PR TITLE
clkmgr: Reset buffer offset before handle new message in MqListenerWork

### DIFF
--- a/clkmgr/client/connect_msg.cpp
+++ b/clkmgr/client/connect_msg.cpp
@@ -23,7 +23,7 @@ DECLARE_STATIC(ClientConnectMessage::currentClientState, nullptr);
 
 bool ClientConnectMessage::writeClientId()
 {
-    rxContext.getQueueName().copy((char *)getClientId().data(), CLIENTID_LENGTH);
+    rxContext.getClientId().copy((char *)getClientId().data(), CLIENTID_LENGTH);
     return true;
 }
 

--- a/clkmgr/common/msgq_tport.cpp
+++ b/clkmgr/common/msgq_tport.cpp
@@ -53,6 +53,7 @@ bool Queue::RxOpen(const string &n, size_t maxMsg)
     if(exist()) {
         rx = true;
         name = n;
+        clientId = name;
         return true;
     }
     return false;

--- a/clkmgr/common/msgq_tport.hpp
+++ b/clkmgr/common/msgq_tport.hpp
@@ -60,6 +60,7 @@ class Queue
     mqd_t mq = invalidMq;
     bool rx = false; // Receive or Transmit
     std::string name;
+    std::string clientId;
   public:
     Queue() = default;
     ~Queue() { close(); remove(); }
@@ -89,6 +90,8 @@ class Queue
     operator std::string() const { return std::to_string(mq); }
     // Get string
     std::string str() const { return std::to_string(mq); }
+    // Get client ID
+    std::string getClientId() const { return clientId; }
 };
 
 class Listener : public Buffer, public End
@@ -116,6 +119,7 @@ class Listener : public Buffer, public End
     bool MqListenerWork();
     std::thread &getThread() { return m_thread; }
     std::string getQueueName() const { return m_listenerQueue.str(); }
+    std::string getClientId() const { return m_listenerQueue.getClientId(); }
 };
 
 class Transmitter : public Buffer

--- a/clkmgr/proxy/connect_chrony.cpp
+++ b/clkmgr/proxy/connect_chrony.cpp
@@ -140,6 +140,7 @@ void ChronyThreadSet::notify_client()
         return;
     for(const sessionId_t sessionId : sessionIdToRemove) {
         ConnectPtp4l::remove_ptp4l_subscriber(sessionId);
+        ConnectChrony::remove_chrony_subscriber(sessionId);
         Client::RemoveClientSession(sessionId);
     }
 }

--- a/clkmgr/proxy/connect_ptp4l.cpp
+++ b/clkmgr/proxy/connect_ptp4l.cpp
@@ -196,6 +196,7 @@ void ptpSet::notify_client()
     }
     local.unlock(); // Explicitly unlock the mutex
     for(const sessionId_t sessionId : sessionIdToRemove) {
+        ConnectPtp4l::remove_ptp4l_subscriber(sessionId);
         #ifdef HAVE_LIBCHRONY
         ConnectChrony::remove_chrony_subscriber(sessionId);
         #endif


### PR DESCRIPTION
1. Fix - clkmgr: Fix sessionId not properly removed for ptp4l and Chrony.

**Description:**
ptp4l:
The unsubscribed session may subscribed to multiple ptpSets (timeBaseIndex).
Therefore, proxy should remove the sessionId from all ptpSets that the session
subscribed to before remove the sessionId from the SessionMap.

Chrony:
The unsubscribed session may subscribed to multiple ChronyThreadSet (timeBaseIndex).
Therefore, proxy should remove the sessionId from all ChronyThreadSet that the
session subscribed to before remove the sessionId from the SessionMap.

In addition, this fix maintains the consistency of ptp4l and Chrony's unsubscribed
behavior.

2. clkmgr: Add Listener's getClientId() method

**Description:**
Introduce `getClientId()` method so that client can put it into
`CONNECT_MSG` which will be send to the proxy.

The proxy will open a message queue for notification based on the received
`clientId`.