### PR TITLE
clkmgr: Refactor Subscription Handling to new subscription classes.

### DIFF
--- a/clkmgr/client/clockmanager.cpp
+++ b/clkmgr/client/clockmanager.cpp
@@ -59,7 +59,7 @@ const TimeBaseConfigurations &ClockManager::getTimebaseCfgs()
     return TimeBaseConfigurations::getInstance();
 }
 
-bool ClockManager::subscribeByName(const ClkMgrSubscription &newSub,
+bool ClockManager::subscribeByName(const ClockSyncSubscription &newSub,
     const string &timeBaseName, ClockSyncData &clockSyncData)
 {
     size_t timeBaseIndex = 0;
@@ -69,7 +69,8 @@ bool ClockManager::subscribeByName(const ClkMgrSubscription &newSub,
     }
     return subscribe(newSub, timeBaseIndex, clockSyncData);
 }
-bool ClockManager::subscribe(const ClkMgrSubscription &newSub,
+
+bool ClockManager::subscribe(const ClockSyncSubscription &newSub,
     size_t timeBaseIndex, ClockSyncData &clockSyncData)
 {
     TimeBaseStates &states = TimeBaseStates::getInstance();

--- a/clkmgr/client/clockmanager_c.cpp
+++ b/clkmgr/client/clockmanager_c.cpp
@@ -47,35 +47,37 @@ bool clkmgr_subscribe(const clkmgr_c_subscription sub, size_t time_base_index,
 {
     if(cur_stat == nullptr || time_base_index == 0)
         return false;
-    ClkMgrSubscription newsub = {};
-    Event_state state = {};
-    bool ret;
-    newsub.set_event_mask(sub.event_mask);
-    newsub.define_threshold(thresholdGMOffset,
-        sub.threshold[Clkmgr_thresholdGMOffset].upper_limit,
-        sub.threshold[Clkmgr_thresholdGMOffset].lower_limit);
-    newsub.define_threshold(thresholdChronyOffset,
-        sub.threshold[Clkmgr_thresholdChronyOffset].upper_limit,
-        sub.threshold[Clkmgr_thresholdChronyOffset].lower_limit);
-    newsub.set_composite_event_mask(sub.composite_event_mask);
-    ret = 0;//ClockManager::subscribe(newsub, time_base_index, state);
-    if(ret) {
-        cur_stat->as_capable = state.as_capable;
-        cur_stat->offset_in_range = state.offset_in_range;
-        cur_stat->synced_to_primary_clock = state.synced_to_primary_clock;
-        cur_stat->gm_changed = state.gm_changed;
-        cur_stat->composite_event = state.composite_event;
-        cur_stat->clock_offset = state.clock_offset;
-        cur_stat->notification_timestamp = state.notification_timestamp;
-        std::copy(std::begin(state.gm_identity), std::end(state.gm_identity),
-            std::begin(cur_stat->gm_identity));
-        cur_stat->ptp4l_sync_interval = state.ptp4l_sync_interval;
-        cur_stat->chrony_clock_offset = state.chrony_clock_offset;
-        cur_stat->chrony_reference_id = state.chrony_reference_id;
-        cur_stat->chrony_offset_in_range = state.chrony_offset_in_range;
-        cur_stat->polling_interval = state.polling_interval;
-    }
-    return ret;
+    return true;
+    // ToDo: Refactor C-wrapper
+    //ClockSubscriptionBasenewsub = {};
+    //Event_state state = {};
+    //bool ret;
+    /*    newsub.setEventMask(sub.event_mask);
+        newsub.define_threshold(thresholdGMOffset,
+            sub.threshold[Clkmgr_thresholdGMOffset].upper_limit,
+            sub.threshold[Clkmgr_thresholdGMOffset].lower_limit);
+        newsub.define_threshold(thresholdChronyOffset,
+            sub.threshold[Clkmgr_thresholdChronyOffset].upper_limit,
+            sub.threshold[Clkmgr_thresholdChronyOffset].lower_limit);
+        newsub.set_composite_event_mask(sub.composite_event_mask);
+        ret = 0;//ClockManager::subscribe(newsub, time_base_index, state);
+        if(ret) {
+            cur_stat->as_capable = state.as_capable;
+            cur_stat->offset_in_range = state.offset_in_range;
+            cur_stat->synced_to_primary_clock = state.synced_to_primary_clock;
+            cur_stat->gm_changed = state.gm_changed;
+            cur_stat->composite_event = state.composite_event;
+            cur_stat->clock_offset = state.clock_offset;
+            cur_stat->notification_timestamp = state.notification_timestamp;
+            std::copy(std::begin(state.gm_identity), std::end(state.gm_identity),
+                std::begin(cur_stat->gm_identity));
+            cur_stat->ptp4l_sync_interval = state.ptp4l_sync_interval;
+            cur_stat->chrony_clock_offset = state.chrony_clock_offset;
+            cur_stat->chrony_reference_id = state.chrony_reference_id;
+            cur_stat->chrony_offset_in_range = state.chrony_offset_in_range;
+            cur_stat->polling_interval = state.polling_interval;
+        }
+     return ret;*/
 }
 
 int clkmgr_status_wait_by_name(int timeout, const char *timeBaseName,

--- a/clkmgr/client/timebase_state.cpp
+++ b/clkmgr/client/timebase_state.cpp
@@ -81,14 +81,27 @@ string TimeBaseState::toString() const
         to_string(eventState.synced_to_primary_clock) + "\n";
 }
 
-const ClkMgrSubscription &TimeBaseState::get_eventSub()
+const PTPClockSubscription &TimeBaseState::get_ptpEventSub()
 {
-    return eventSub;
+    return ptpEventSub;
 }
 
-void TimeBaseState::set_eventSub(const ClkMgrSubscription &eSub)
+const SysClockSubscription &TimeBaseState::get_sysEventSub()
 {
-    eventSub.set_ClkMgrSubscription(eSub);
+    return sysEventSub;
+}
+
+void TimeBaseState::set_ptpEventSub(const PTPClockSubscription &eSub)
+{
+    ptpEventSub.setEventMask(eSub.getEventMask());
+    ptpEventSub.setClockOffsetThreshold(eSub.getClockOffsetThreshold());
+    ptpEventSub.setCompositeEventMask(eSub.getCompositeEventMask());
+}
+
+void TimeBaseState::set_sysEventSub(const SysClockSubscription &eSub)
+{
+    sysEventSub.setEventMask(eSub.getEventMask());
+    sysEventSub.setClockOffsetThreshold(eSub.getClockOffsetThreshold());
 }
 
 void TimeBaseState::set_last_notification_time(const timespec &newTime)
@@ -140,18 +153,24 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
     else
         state.set_last_notification_time(last_notification_time);
     // Get a copy of subscription mask
-    ClkMgrSubscription sub = state.get_eventSub();
-    uint32_t eventSub = sub.get_event_mask();
-    uint32_t composite_eventSub = sub.get_composite_event_mask();
+    PTPClockSubscription ptpSub = state.get_ptpEventSub();
+    SysClockSubscription sysSub = state.get_sysEventSub();
+    uint32_t ptpEventSub = ptpSub.getEventMask();
+    uint32_t ptpCompositeEventSub = ptpSub.getCompositeEventMask();
+    int32_t ptpThreshold = static_cast<uint32_t>(ptpSub.getClockOffsetThreshold());
+    int32_t sysThreshold = static_cast<uint32_t>(sysSub.getClockOffsetThreshold());
+    //uint32_t sysEventSub = sysSub.getEventMask();
     // Get the current state of the timebase
     PTPClockEvent ptp4lEventState = state.get_ptp4lEventState();
     SysClockEvent chronyEventState = state.get_chronyEventState();
     // Update eventGMOffset
-    if((eventSub & eventGMOffset) &&
+    if((ptpEventSub & eventGMOffset) &&
         (newEvent.master_offset != ptp4lEventState.getClockOffset())) {
         ptpClockEventHandler.setClockOffset(ptp4lEventState,
             newEvent.master_offset);
-        if(sub.in_range(thresholdGMOffset, ptp4lEventState.getClockOffset())) {
+        bool ptpInRange = (ptp4lEventState.getClockOffset() >= -ptpThreshold)
+            && (ptp4lEventState.getClockOffset() <= ptpThreshold);
+        if(ptpInRange) {
             if(!(ptp4lEventState.isOffsetInRange())) {
                 ptpClockEventHandler.setOffsetInRange(ptp4lEventState, true);
                 ptpClockEventHandler.setOffsetInRangeEventCount(ptp4lEventState,
@@ -168,7 +187,7 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
         }
     }
     // Update eventSyncedToGM
-    if((eventSub & eventSyncedToGM) &&
+    if((ptpEventSub & eventSyncedToGM) &&
         (newEvent.synced_to_primary_clock !=
             ptp4lEventState.isSyncedWithGm())) {
         ptpClockEventHandler.setSyncedWithGm(ptp4lEventState,
@@ -184,7 +203,7 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
         sourceClockUUIDBytes[i] =
             static_cast<uint8_t>(sourceClockUUID >>(8 * (7 - i)));
     }
-    if((eventSub & eventGMChanged) &&
+    if((ptpEventSub & eventGMChanged) &&
         (memcmp(sourceClockUUIDBytes, newEvent.gm_identity,
                 sizeof(newEvent.gm_identity)) != 0)) {
         uint64_t identity = 0;
@@ -199,7 +218,7 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
         state.set_event_changed(true);
     }
     // Update eventASCapable
-    if((eventSub & eventASCapable) &&
+    if((ptpEventSub & eventASCapable) &&
         (newEvent.as_capable != ptp4lEventState.isAsCapable())) {
         ptpClockEventHandler.setAsCapable(ptp4lEventState, newEvent.as_capable);
         ptpClockEventHandler.setAsCapableEventCount(ptp4lEventState,
@@ -208,13 +227,13 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
     }
     // Update composite event
     bool composite_event = true;
-    if(composite_eventSub & eventGMOffset)
+    if(ptpCompositeEventSub & eventGMOffset)
         composite_event &= ptp4lEventState.isOffsetInRange();
-    if(composite_eventSub & eventSyncedToGM)
+    if(ptpCompositeEventSub & eventSyncedToGM)
         composite_event &= ptp4lEventState.isSyncedWithGm();
-    if(composite_eventSub & eventASCapable)
+    if(ptpCompositeEventSub & eventASCapable)
         composite_event &= ptp4lEventState.isAsCapable();
-    if(composite_eventSub &&
+    if(ptpCompositeEventSub &&
         (composite_event != ptp4lEventState.isCompositeEventMet())) {
         ptpClockEventHandler.setCompositeEvent(ptp4lEventState,
             composite_event);
@@ -235,8 +254,9 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
     if(newEvent.chrony_offset != chronyEventState.getClockOffset()) {
         sysClockEventHandler.setClockOffset(chronyEventState,
             newEvent.chrony_offset);
-        if(sub.in_range(thresholdChronyOffset,
-                chronyEventState.getClockOffset())) {
+        bool sysInRange = (chronyEventState.getClockOffset() >= -sysThreshold) &&
+            (chronyEventState.getClockOffset() <= sysThreshold);
+        if(sysInRange) {
             if(!(chronyEventState.isOffsetInRange())) {
                 sysClockEventHandler.setOffsetInRange(chronyEventState, true);
                 sysClockEventHandler.setOffsetInRangeEventCount(chronyEventState,
@@ -261,7 +281,7 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
 }
 
 bool TimeBaseStates::subscribe(size_t timeBaseIndex,
-    const ClkMgrSubscription &newSub)
+    const ClockSyncSubscription &newSub)
 {
     ClientState &implClientState = ClientState::getSingleInstance();
     // Check whether connection between Proxy and Client is established or not
@@ -274,7 +294,15 @@ bool TimeBaseStates::subscribe(size_t timeBaseIndex,
         PrintDebug("[SUBSCRIBE] Invalid timeBaseIndex.");
         return false;
     }
-    setEventSubscription(timeBaseIndex, newSub);
+    if(newSub.isPTPSubscriptionEnable()) {
+        const PTPClockSubscription &newPtpSub = newSub.getPtpSubscription();
+        setPtpEventSubscription(timeBaseIndex, newPtpSub);
+    }
+    // ToDo: Check whether system clock is available for subscription
+    if(newSub.isSysSubscriptionEnable()) {
+        const SysClockSubscription &newSysSub = newSub.getSysSubscription();
+        setSysEventSubscription(timeBaseIndex, newSysSub);
+    }
     // Send a subscribe message to Proxy Daemon
     ClientSubscribeMessage *cmsg = new ClientSubscribeMessage();
     if(cmsg == nullptr) {

--- a/clkmgr/client/timebase_state.hpp
+++ b/clkmgr/client/timebase_state.hpp
@@ -34,7 +34,8 @@ class TimeBaseState
     Event_state eventState = {}; /**< Event state */
     PTPClockEvent ptp4lEventState; /**< PTP4L Event state */
     SysClockEvent chronyEventState; /**< Chrony Event state */
-    ClkMgrSubscription eventSub = {}; /**< Event subscription */
+    PTPClockSubscription ptpEventSub; /**< PTP Event subscription */
+    SysClockSubscription sysEventSub; /**< Chrony Event subscription */
     timespec last_notification_time = {}; /**< Last notification time */
 
   public:
@@ -105,16 +106,28 @@ class TimeBaseState
     std::string toString() const;
 
     /**
-     * Get the event subscription
-     * @return Reference to the event subscription
+     * Get the PTP event subscription
+     * @return Reference to the PTP event subscription
      */
-    const ClkMgrSubscription &get_eventSub();
+    const PTPClockSubscription &get_ptpEventSub();
 
     /**
-     * Set the event subscription
-     * @param[in] eSub event subscription
+     * Get the system clock event subscription
+     * @return Reference to the system clock event subscription
      */
-    void set_eventSub(const ClkMgrSubscription &eSub);
+    const SysClockSubscription &get_sysEventSub();
+
+    /**
+     * Set the PTP event subscription
+     * @param[in] eSub PTP event subscription
+     */
+    void set_ptpEventSub(const PTPClockSubscription &eSub);
+
+    /**
+     * Set the system clock event subscription
+     * @param[in] eSub System clock event subscription
+     */
+    void set_sysEventSub(const SysClockSubscription &eSub);
 };
 
 /**
@@ -143,11 +156,20 @@ class TimeBaseStates
     // Method to set TimeBaseState by timeBaseIndex
     void setTimeBaseState(size_t timeBaseIndex, const ptp_event &event);
 
-    // Method to set ClkMgrSubscription by timeBaseIndex
-    void setEventSubscription(size_t timeBaseIndex, const ClkMgrSubscription &sub) {
+    // Method to set PTPClockSubscription by timeBaseIndex
+    void setPtpEventSubscription(int timeBaseIndex,
+        const PTPClockSubscription &sub) {
         std::lock_guard<rtpi::mutex> lock(mtx);
         auto &state = timeBaseStateMap[timeBaseIndex];
-        state.set_eventSub(sub);
+        state.set_ptpEventSub(sub);
+    }
+
+    // Method to set SysClockSubscription by timeBaseIndex
+    void setSysEventSubscription(int timeBaseIndex,
+        const SysClockSubscription &sub) {
+        std::lock_guard<rtpi::mutex> lock(mtx);
+        auto &state = timeBaseStateMap[timeBaseIndex];
+        state.set_sysEventSub(sub);
     }
 
     // Method to get the subscription status by timeBaseIndex
@@ -181,7 +203,7 @@ class TimeBaseStates
     }
 
     // Send Client subscribe message
-    bool subscribe(size_t timeBaseIndex, const ClkMgrSubscription &newSub);
+    bool subscribe(size_t timeBaseIndex, const ClockSyncSubscription &newSub);
     bool subscribeReply(size_t timeBaseIndex, const ptp_event &data);
 };
 

--- a/clkmgr/common/clock_event_handler.hpp
+++ b/clkmgr/common/clock_event_handler.hpp
@@ -74,10 +74,11 @@ class ClockEventHandler
     /**
      * Set whether the offset is in range for a ClockEventBase object.
      * @param[in] event The ClockEventBase object to modify.
-     * @param[in] in_range True if the offset is in range, false otherwise.
+     * @param[in] isClockOffsetInRange True if the offset is in range,
+     * false otherwise.
      */
-    static void setOffsetInRange(ClockEventBase &event, bool in_range) {
-        event.offsetInRange = in_range;
+    static void setOffsetInRange(ClockEventBase &event, bool isClockOffsetInRange) {
+        event.offsetInRange = isClockOffsetInRange;
     }
 
     /**

--- a/clkmgr/common/subscribe_msg.cpp
+++ b/clkmgr/common/subscribe_msg.cpp
@@ -42,9 +42,6 @@ bool SubscribeMessage::makeBufferComm(Buffer &buff) const
 {
     PrintDebug("[SubscribeMessage]::makeBufferComm - sessionId : " +
         to_string(get_sessionId()));
-    PrintDebug("[SubscribeMessage]::makeBufferComm - subscription event : " +
-        to_string(subscription.get_event_mask()) + ", composite event : " +
-        to_string(subscription.get_composite_event_mask()));
     return WRITE_TX(FIELD, get_sessionId(), buff) &&
         WRITE_TX(FIELD, subscription, buff) &&
         WRITE_TX(FIELD, timeBaseIndex, buff);

--- a/clkmgr/common/subscribe_msg.hpp
+++ b/clkmgr/common/subscribe_msg.hpp
@@ -21,7 +21,7 @@ __CLKMGR_NAMESPACE_BEGIN
 class SubscribeMessage : public Message
 {
   private:
-    ClkMgrSubscription subscription;
+    ClockSubscriptionBase subscription;
     bool parseBufferComm() override final;
     bool makeBufferComm(Buffer &buff) const override final;
 
@@ -34,7 +34,7 @@ class SubscribeMessage : public Message
 
     // Seems the Clock manager subscription is left in the client
     // TODO Why do we send it in the Subscribe Message?
-    const ClkMgrSubscription &getSubscription() const { return subscription; }
+    const ClockSubscriptionBase &getSubscription() const { return subscription; }
     // void setSubscription(const ClkMgrSubscription &newsub);
 
     std::string toString() const override;

--- a/clkmgr/common/subscription.cpp
+++ b/clkmgr/common/subscription.cpp
@@ -13,59 +13,99 @@
 
 __CLKMGR_NAMESPACE_USE;
 
-ClkMgrSubscription::ClkMgrSubscription() noexcept : m_event_mask(0),
-    m_composite_event_mask(0) {}
+ClockSubscriptionBase::ClockSubscriptionBase() noexcept : eventMask(0) {}
 
-void ClkMgrSubscription::set_ClkMgrSubscription(const ClkMgrSubscription &n)
+void ClockSubscriptionBase::setClockOffsetThreshold(uint32_t threshold)
 {
-    m_event_mask = n.m_event_mask;
-    m_composite_event_mask = n.m_composite_event_mask;
-    m_threshold = n.m_threshold;
+    clockOffsetThreshold = threshold;
 }
 
-void ClkMgrSubscription::set_event_mask(uint32_t event_mask)
+uint32_t ClockSubscriptionBase::getClockOffsetThreshold() const
 {
-    m_event_mask = event_mask;
+    return clockOffsetThreshold;
 }
 
-uint32_t ClkMgrSubscription::get_event_mask() const
+void ClockSubscriptionBase::setEventMask(uint32_t newEventMask)
 {
-    return m_event_mask;
+    eventMask = newEventMask;
 }
 
-void ClkMgrSubscription::set_composite_event_mask(uint32_t composite_event_mask)
+uint32_t ClockSubscriptionBase::getEventMask() const
+{
+    return eventMask;
+}
+
+void PTPClockSubscription::setCompositeEventMask(uint32_t
+    composite_event_mask)
 {
     m_composite_event_mask = composite_event_mask;
 }
 
-uint32_t ClkMgrSubscription::get_composite_event_mask() const
+uint32_t PTPClockSubscription::getCompositeEventMask() const
 {
     return m_composite_event_mask;
 }
 
-bool ClkMgrSubscription::define_threshold(ThresholdIndex index, int32_t upper,
-    int32_t lower)
+PTPClockSubscription::PTPClockSubscription() noexcept
+    : m_composite_event_mask(0) {}
+
+SysClockSubscription::SysClockSubscription() noexcept
+    : ClockSubscriptionBase() {}
+
+ClockSyncSubscription::ClockSyncSubscription()
 {
-    if(index >= thresholdLast || upper <= lower)
-        return false;
-    m_threshold[index].upper_limit = upper;
-    m_threshold[index].lower_limit = lower;
-    return true;
+    ptpSubscribed = false;
+    sysSubscribed = false;
 }
 
-bool ClkMgrSubscription::get_threshold(ThresholdIndex index, int32_t &upper,
-    int32_t &lower)
+void ClockSyncSubscription::enablePtpSubscription()
 {
-    if(index >= thresholdLast)
-        return false;
-    upper = m_threshold[index].upper_limit;
-    lower = m_threshold[index].lower_limit;
-    return true;
+    ptpSubscribed = true;
 }
 
-bool ClkMgrSubscription::in_range(ThresholdIndex index, int32_t value) const
+void ClockSyncSubscription::disablePtpSubscription()
 {
-    return index < thresholdLast &&
-        value >= m_threshold[index].lower_limit &&
-        value <= m_threshold[index].upper_limit;
+    ptpSubscribed = false;
+}
+
+bool ClockSyncSubscription::isPTPSubscriptionEnable() const
+{
+    return ptpSubscribed;
+}
+
+void ClockSyncSubscription::setPtpSubscription(
+    const PTPClockSubscription &newPtpSub)
+{
+    ptpSubscription = newPtpSub;
+}
+
+const PTPClockSubscription &ClockSyncSubscription::getPtpSubscription() const
+{
+    return ptpSubscription;
+}
+
+void ClockSyncSubscription::enableSysSubscription()
+{
+    sysSubscribed = true;
+}
+
+void ClockSyncSubscription::disableSysSubscription()
+{
+    sysSubscribed = false;
+}
+
+bool ClockSyncSubscription::isSysSubscriptionEnable() const
+{
+    return sysSubscribed;
+}
+
+void ClockSyncSubscription::setSysSubscription(
+    const SysClockSubscription &newSysSub)
+{
+    sysSubscription = newSysSub;
+}
+
+const SysClockSubscription &ClockSyncSubscription::getSysSubscription() const
+{
+    return sysSubscription;
 }

--- a/clkmgr/common/types.m4
+++ b/clkmgr/common/types.m4
@@ -47,27 +47,6 @@ enum Nm(EventIndex) sz(`: uint32_t '){
 cnst(uint8_t,THRESHOLD_MAX,8)
 
 /**
- * Index of events which require user to provide predefined threshold.
- *
- * @note The thresholdLast is reserved for future use. The maximum number of
- * events which can have threshold is NM(THRESHOLD_MAX).
- */
-enum Nm(ThresholdIndex) sz(`: uint8_t '){
-    Nm(thresholdGMOffset),  /**< threshold for primary-secondary clock offset */
-    Nm(thresholdChronyOffset),  /**< threshold for chrony clock offset */
-    Nm(thresholdLast)           /**< Last threshold */
-};
-
-/**
- * Structure to hold upper and lower limits
- */
-struct Nm(Threshold) {
-    int32_t upper_limit; /**< Upper limit */
-    int32_t lower_limit; /**< Lower limit */
-cpp_cod(`    Threshold() noexcept : upper_limit(0), lower_limit(0) {}')dnl
-};
-
-/**
  * Structure to represent the current state of events.
  */
 struct Nm(Event_state) {

--- a/clkmgr/pub/clkmgr/clockmanager_c.h
+++ b/clkmgr/pub/clkmgr/clockmanager_c.h
@@ -27,7 +27,7 @@ extern "C" {
 struct clkmgr_c_subscription {
     uint32_t event_mask; /**< Events subscription mask */
     uint32_t composite_event_mask; /**< Composite events mask */
-    struct Clkmgr_Threshold threshold[CLKMGR_THRESHOLD_MAX]; /**< Limits */
+    /*struct Clkmgr_Threshold threshold[CLKMGR_THRESHOLD_MAX];*/ /**< Limits */
 };
 
 /**

--- a/clkmgr/pub/clkmgr/subscription.h
+++ b/clkmgr/pub/clkmgr/subscription.h
@@ -2,7 +2,7 @@
    SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation. */
 
 /** @file
- * @brief class, structures and enums used for events subsciption
+ * @brief Set clock event subsciption.
  *
  * @author Christopher Hall <christopher.s.hall@@intel.com>
  * @copyright © 2024 Intel Corporation.
@@ -19,75 +19,148 @@
 __CLKMGR_NAMESPACE_BEGIN
 
 /**
- * Class to hold the event subscription masks, composite event mask, and
- * thresholds for events that require user-defined threshold (upper and lower
- * limits).
+ * Manage event masks and clock offset thresholds for clock synchronization
+ * event subscriptions.
  */
-class ClkMgrSubscription
+class ClockSubscriptionBase
 {
-  private:
-    uint32_t m_event_mask; /**< Event subscription mask */
-    uint32_t m_composite_event_mask; /**< Composite event mask */
-    std::array<Threshold, THRESHOLD_MAX> m_threshold; /**< Upper & lower limits */
-
   public:
-    ClkMgrSubscription() noexcept;
+    ClockSubscriptionBase() noexcept;
 
     /**
-     * Set the Subscription masks.
-     * @param[in] newSubscription The new event mask to set.
+     * Set the event mask
+     * @param[in] newEventMask The new event mask to set
      */
-    void set_ClkMgrSubscription(const ClkMgrSubscription &newSubscription);
+    void setEventMask(uint32_t newEventMask);
 
     /**
-     * Set the event mask.
-     * @param[in] event_mask The new event mask to set.
+     * Get the value of the event mask
+     * @return The value of the event mask
      */
-    void set_event_mask(uint32_t event_mask);
+    uint32_t getEventMask() const;
 
     /**
-     * Get the value of the event mask.
-     * @return The value of the event mask.
+     * Set the threshold of clock offset
+     * @param[in] threshold Threshold of clock offset
+     * @note The threshold sets a symmetric range of clock offset
      */
-    uint32_t get_event_mask() const;
+    void setClockOffsetThreshold(uint32_t threshold);
+
+    /**
+     * Get the threshold of clock offset
+     * @return Threshold of clock offset
+     */
+    uint32_t getClockOffsetThreshold() const;
+
+  private:
+    uint32_t clockOffsetThreshold;
+    uint32_t eventMask;
+};
+
+/**
+ * Manage event masks and clock offset thresholds for PTP clock synchronization
+ * event subscriptions.
+ */
+class PTPClockSubscription : public ClockSubscriptionBase
+{
+  public:
+    PTPClockSubscription() noexcept;
 
     /**
      * Set the composite event mask.
      * @param[in] composite_event_mask The new composite event mask to set.
      */
-    void set_composite_event_mask(uint32_t composite_event_mask);
+    void setCompositeEventMask(uint32_t composite_event_mask);
 
     /**
      * Get the value of the composite event mask.
-     * @return the composite event mask.
+     * @return The composite event mask.
      */
-    uint32_t get_composite_event_mask() const;
+    uint32_t getCompositeEventMask() const;
+
+  private:
+    uint32_t m_composite_event_mask;
+};
+
+/**
+ * Manage event masks and clock offset thresholds for system clock
+ * synchronization event subscriptions.
+ */
+class SysClockSubscription : public ClockSubscriptionBase
+{
+  public:
+    SysClockSubscription() noexcept;
+};
+
+/**
+ * Provide overview of clock event subscriptions to Clock Manager.
+ */
+class ClockSyncSubscription
+{
+  public:
+    ClockSyncSubscription();
 
     /**
-     * Define the upper and lower limits of a specific event
-     * @param[in] index Index of the event according to ThresholdIndex enum
-     * @param[in] upper Upper limit
-     * @param[in] lower Lower limit
-     * @return true on success, false on failure
+     * Enable the subscription of the PTP clock.
      */
-    bool define_threshold(ThresholdIndex index, int32_t upper, int32_t lower);
+    void enablePtpSubscription();
 
     /**
-     * get the upper and lower limits of a specific event
-     * @param[in] index Index of the event according to ThresholdIndex enum
-     * @param[out] upper Upper limit
-     * @param[out] lower Lower limit
-     * @return true on success, false on failure
+     * Disable the subscription of the PTP clock.
      */
-    bool get_threshold(ThresholdIndex index, int32_t &upper, int32_t &lower);
+    void disablePtpSubscription();
 
     /**
-     * Check whether a given value is within predefined threshold
-     * @param[in] index Index of the event according to ThresholdIndex enum
-     * @param[in] value Current value
-     * @return Return true if value is within the threshold, and false otherwise
+     * Check if the PTP clock subscription is enabled
+     * @return True if the PTP clock subscription is enabled, false otherwise
      */
-    bool in_range(ThresholdIndex index, int32_t value) const;
+    bool isPTPSubscriptionEnable() const;
+
+    /**
+     * Set the PTP clock subscription with a new PTPClockSubscription object
+     * @param[in] newPtpSub The new PTPClockSubscription object to update
+     */
+    void setPtpSubscription(const PTPClockSubscription &newPtpSub);
+
+    /**
+     * Retrieve the PTP clock manager subscription.
+     * @return A constant reference to the PTP clock manager subscription.
+     */
+    const PTPClockSubscription &getPtpSubscription() const;
+
+    /**
+     * Enable the subscription of the system clock.
+     */
+    void enableSysSubscription();
+
+    /**
+     * Disable the subscription of the system clock.
+     */
+    void disableSysSubscription();
+
+    /**
+     * Check if the system clock subscription is enabled
+     * @return True if the system clock subscription is enabled, false otherwise
+     */
+    bool isSysSubscriptionEnable() const;
+
+    /**
+     * Set the system clock subscription with a new SysClockSubscription object
+     * @param[in] newSysSub The new SysClockSubscription object to update
+     */
+    void setSysSubscription(const SysClockSubscription &newSysSub);
+
+    /**
+     * Retrieve the system clock manager subscription.
+     * @return A constant reference to the system clock manager subscription.
+     */
+    const SysClockSubscription &getSysSubscription() const;
+
+  private:
+    PTPClockSubscription ptpSubscription;
+    SysClockSubscription sysSubscription;
+    bool ptpSubscribed;
+    bool sysSubscribed;
 };
 
 __CLKMGR_NAMESPACE_END

--- a/clkmgr/pub/clockmanager.h
+++ b/clkmgr/pub/clockmanager.h
@@ -66,9 +66,8 @@ class ClockManager
      * @return True on successful subscription, false on failure
      * @note Event counting will begin once this API is called
      */
-    static bool subscribeByName(const ClkMgrSubscription &newSub,
-        const std::string &timeBaseName,
-        ClockSyncData &clockSyncData);
+    static bool subscribeByName(const ClockSyncSubscription &newSub,
+        const std::string &timeBaseName, ClockSyncData &clockSyncData);
 
     /**
      * Subscribe to specific time-base by providing timeBaseIndex and interested
@@ -80,8 +79,8 @@ class ClockManager
      * @return True on successful subscription, false on failure
      * @note Event counting will begin once this API is called
      */
-    static bool subscribe(const ClkMgrSubscription &newSub, size_t timeBaseIndex,
-        ClockSyncData &clockSyncData);
+    static bool subscribe(const ClockSyncSubscription &newSub,
+        size_t timeBaseIndex, ClockSyncData &clockSyncData);
 
     /**
      * Wait for status changes in the specified time-base by providing the

--- a/clkmgr/sample/clkmgr_c_test.c
+++ b/clkmgr/sample/clkmgr_c_test.c
@@ -57,11 +57,11 @@ int main(int argc, char *argv[])
         Clkmgr_eventASCapable | Clkmgr_eventGMChanged);
     subscription.composite_event_mask = (Clkmgr_eventGMOffset |
         Clkmgr_eventSyncedToGM | Clkmgr_eventASCapable);
-    subscription.threshold[Clkmgr_thresholdGMOffset].upper_limit = 100000;
+/*    subscription.threshold[Clkmgr_thresholdGMOffset].upper_limit = 100000;
     subscription.threshold[Clkmgr_thresholdGMOffset].lower_limit = -100000;
     subscription.threshold[Clkmgr_thresholdChronyOffset].upper_limit = 100000;
     subscription.threshold[Clkmgr_thresholdChronyOffset].lower_limit = -100000;
-
+*/
     while ((option = getopt(argc, argv, "aps:c:u:l:i:t:m:n:h")) != -1) {
         switch (option) {
         case 'a':
@@ -76,7 +76,7 @@ int main(int argc, char *argv[])
         case 'c':
             subscription.composite_event_mask = strtoul(optarg, NULL, 0);
             break;
-        case 'u':
+/*        case 'u':
             subscription.threshold[Clkmgr_thresholdGMOffset].upper_limit =
                 strtol(optarg, NULL, 10);
             break;
@@ -84,13 +84,13 @@ int main(int argc, char *argv[])
             subscription.threshold[Clkmgr_thresholdGMOffset].lower_limit =
                 strtol(optarg, NULL, 10);
             break;
-        case 'i':
+*/        case 'i':
             idle_time = strtol(optarg, NULL, 10);
             break;
         case 't':
             timeout = strtol(optarg, NULL, 10);
             break;
-        case 'm':
+/*        case 'm':
             subscription.threshold[Clkmgr_thresholdChronyOffset].upper_limit =
                 strtol(optarg, NULL, 10);
             break;
@@ -98,7 +98,7 @@ int main(int argc, char *argv[])
             subscription.threshold[Clkmgr_thresholdChronyOffset].lower_limit =
                 strtol(optarg, NULL, 10);
             break;
-        case 'h':
+*/        case 'h':
             printf("Usage of %s :\n"
                    "Options:\n"
                    "  -a subscribe to all time base indices\n"
@@ -115,25 +115,25 @@ int main(int argc, char *argv[])
                    "     Bit 0: eventGMOffset\n"
                    "     Bit 1: eventSyncedToGM\n"
                    "     Bit 2: eventASCapable\n"
-                   "  -u gm offset upper limit (ns)\n"
+/*                   "  -u gm offset upper limit (ns)\n"
                    "     Default: %d ns\n"
                    "  -l gm offset lower limit (ns)\n"
                    "     Default: %d ns\n"
-                   "  -i idle time (s)\n"
+*/                   "  -i idle time (s)\n"
                    "     Default: %d s\n"
-                   "  -m chrony offset upper limit (ns)\n"
+/*                   "  -m chrony offset upper limit (ns)\n"
                    "     Default: %d ns\n"
                    "  -n chrony offset lower limit (ns)\n"
                    "     Default: %d ns\n"
-                   "  -t timeout in waiting notification event (s)\n"
+*/                   "  -t timeout in waiting notification event (s)\n"
                    "     Default: %d s\n",
                    argv[0], subscription.event_mask,
                    subscription.composite_event_mask,
-                   subscription.threshold[Clkmgr_thresholdGMOffset].upper_limit,
+/*                   subscription.threshold[Clkmgr_thresholdGMOffset].upper_limit,
                    subscription.threshold[Clkmgr_thresholdGMOffset].lower_limit,
                    subscription.threshold[Clkmgr_thresholdChronyOffset].upper_limit,
-                   subscription.threshold[Clkmgr_thresholdChronyOffset].lower_limit,
-                   idle_time, timeout);
+                   subscription.threshold[Clkmgr_thresholdChronyOffset].lower_limit,s
+*/                   idle_time, timeout);
             return EXIT_SUCCESS;
         default:
             printf("Usage of %s :\n"
@@ -152,25 +152,25 @@ int main(int argc, char *argv[])
                    "     Bit 0: eventGMOffset\n"
                    "     Bit 1: eventSyncedToGM\n"
                    "     Bit 2: eventASCapable\n"
-                   "  -u gm offset upper limit (ns)\n"
+/*                   "  -u gm offset upper limit (ns)\n"
                    "     Default: %d ns\n"
                    "  -l gm offset lower limit (ns)\n"
                    "     Default: %d ns\n"
-                   "  -i idle time (s)\n"
+*/                   "  -i idle time (s)\n"
                    "     Default: %d s\n"
-                   "  -m chrony offset upper limit (ns)\n"
+/*                   "  -m chrony offset upper limit (ns)\n"
                    "     Default: %d ns\n"
                    "  -n chrony offset lower limit (ns)\n"
                    "     Default: %d ns\n"
-                   "  -t timeout in waiting notification event (s)\n"
+*/                   "  -t timeout in waiting notification event (s)\n"
                    "     Default: %d s\n",
                    argv[0], subscription.event_mask,
                    subscription.composite_event_mask,
-                   subscription.threshold[Clkmgr_thresholdGMOffset].upper_limit,
+/*                   subscription.threshold[Clkmgr_thresholdGMOffset].upper_limit,
                    subscription.threshold[Clkmgr_thresholdGMOffset].lower_limit,
                    subscription.threshold[Clkmgr_thresholdChronyOffset].upper_limit,
                    subscription.threshold[Clkmgr_thresholdChronyOffset].lower_limit,
-                   idle_time, timeout);
+*/                   idle_time, timeout);
             return EXIT_FAILURE;
         }
     }


### PR DESCRIPTION
<h1>Suggested PR Title - Refactor ClockManager Subscription Handling to Use New Subscription Classes</h1>
This patch refactors the subscription handling mechanism within the ClockManager module.

The changes include:
- Replacing the ClkMgrSubscription with ClockSyncSubscription in the subscribe and subscribeByName methods to encapsulate both PTP and SysClock subscriptions.
- Updating the TimeBaseState and TimeBaseStates classes to separately manage PTP and SysClock event subscriptions.
- Modifying the subscription logic to handle composite event masks specifically for PTP subscriptions.
- Adjusting the clkmgr_test sample application to utilize the new ClockSyncSubscription class for subscribing to time base indices.
- Removing unused code and comments related to the previous subscription handling approach.

These changes aim to improve the modularity and clarity of the subscription management process, facilitating better synchronization between PTP and system clocks.

Tested with difference subscription scenario:
1. subscribe to all events
![image](https://github.com/user-attachments/assets/0a7017a5-7382-4f2d-81c2-86515eaf2dd4)

2. subscribe to only 3 events (-s 7) and 2 composite events (-c 3)
![image](https://github.com/user-attachments/assets/84cb8487-a45a-47ad-8d92-df2ae73720eb)

<h1 style='color: red;'>${\color{red}DO \space NOT \space EDIT \space ANYTHING}$</h1>

### Smart DevOps AI Agent for GitHub: Release Version: v1.2-ww18-2025


>### Start of generated PR Summary by Smart DevOps Agent for GitHub

## Types of major changes in the pull request
feature_enhancement, code_enhancement


___

## Pull request change summary
- Refactored subscription handling in the ClockManager module to use ClockSyncSubscription, separating PTP and SysClock subscriptions.
- Updated TimeBaseState and TimeBaseStates classes to handle these subscriptions separately.
- Introduced new classes PtpClkMgrSubscription and SysClockMgrSubscription for managing PTP and system clock subscriptions, respectively.
- Adjusted the clkmgr_test sample application to utilize the new subscription classes.
- Removed outdated debug print statements and unused code segments related to the old subscription mechanism.


___

## High level Pull Request Summary
<table><thead><tr><th>Filename&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Summary of changes&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Link to file&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody>
<tr>
  <td><strong>clkmgr/client/clockmanager.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Refactored the subscription handling in ClockManager class <br>to use ClockSyncSubscription instead of ClkMgrSubscription. <br>This includes updates in subscribe and subscribeByName <br>methods to handle PTP and SysClock subscriptions separately. <br><br><br> Type of change: Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/220/files#diff-2f93f3abd0c220a988e8802733bbe861ccc4ccfba1c46130ce1b7ed68c950382"> +7/-3</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/client/timebase_state.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated TimeBaseState and TimeBaseStates classes to handle <br>PTP and SysClock subscriptions separately. Added methods for <br>setting and getting PTP and SysClock specific subscriptions. <br><br><br> Type of change: Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/220/files#diff-9377401fe8c6585d9e3cb535ac48e73e24e1e6794d28afe70544100f882ba2a7"> +29/-18</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/client/timebase_state.hpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added new member variables and methods in TimeBaseState <br>class for handling PTP and SysClock subscriptions <br>separately. This includes getters and setters for both <br>subscription types. <br><br> Type of change: <br>Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/220/files#diff-a48b952ab5d2906f73cd82992e976c0c051e0e5bd8309662fc25e66ea0781146"> +32/-9</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/common/subscription.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Major overhaul of subscription handling, separating PTP and <br>SysClock related functionalities into PtpClkMgrSubscription <br>and SysClockMgrSubscription classes derived from <br>ClkMgrSubscription. <br><br> Type of change: <br>Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/220/files#diff-a6333a8ed9784f45207be88fd3a300f8e6152842d9734c055d5f7ef89f0f9d61"> +25/-27</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/sample/clkmgr_test.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the sample application clkmgr_test to use the new <br>PtpClkMgrSubscription and SysClockMgrSubscription classes <br>for subscribing to clock events. <br><br> Type of change: <br>Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/220/files#diff-39d8863e2f42d4a016139a23a804368bc9d910f36a372ee321de5dd51f85697e"> +11/-8</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/pub/clkmgr/subscription.h</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Introduced PtpClkMgrSubscription and SysClockMgrSubscription <br>classes for handling PTP and system clock subscriptions <br>separately. Added ClockSyncSubscription class to encapsulate <br>both subscription types. <br><br> Type of change: <br>Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/220/files#diff-04e14f64689c91445532a0f3b3f0c5375b0e7d6b441221544408761e0c2f0d50"> +89/-25</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/pub/clockmanager.h</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the ClockManager class's public API to use <br>ClockSyncSubscription for the subscribe and subscribeByName <br>methods. <br><br> Type of change: Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/220/files#diff-bba6502ccf07abd754f126a37fb5d7002bd0651da0512069bba0a34fd2baac61"> +3/-2</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/client/clockmanager_c.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Commented out the previous subscription logic in <br>clkmgr_subscribe function, indicating a shift towards using <br>the new subscription classes directly in the C++ API rather <br>than through the C interface. <br><br> Type of change: <br>Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/220/files#diff-e018f4d845fa1379731ded3811b94b54e8b40febad5eca6b4e75ca5227ccb6ad"> +28/-28</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/common/subscribe_msg.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Removed debug print statements related to event and <br>composite event masks in CommonSubscribeMessage class, <br>simplifying the message construction process. <br><br> Type <br>of change: Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/220/files#diff-d700cbb602b99b4fdecb278e47adb6d0f926bbafc0e8d15522511748170e4b98"> +0/-3</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

>### End of generated PR Summary by Smart DevOps Agent for GitHub