### PR TITLE
clkmgr:Fix sysAvailability assignment

### DIFF
--- a/clkmgr/common/clock_event.cpp
+++ b/clkmgr/common/clock_event.cpp
@@ -141,7 +141,7 @@ void ClockSyncBaseHandler::setPTPAvailability(bool available)
 
 void ClockSyncBaseHandler::setSysAvailability(bool available)
 {
-    clockSyncData.ptpAvailable = available;
+    clockSyncData.sysAvailable = available;
 }
 
 void ClockSyncBaseHandler::updatePTPClock(const PTPClockEvent &newPTPClock)


### PR DESCRIPTION
This patch corrects the assignment in `setSysAvailability()` method to update the `sysAvailable` field instead of `ptpAvailable`.