### PR TITLE
clkmgr: Fix Chrony connection handling

### DIFF
--- a/clkmgr/proxy/connect_chrony.cpp
+++ b/clkmgr/proxy/connect_chrony.cpp
@@ -143,6 +143,8 @@ chrony_err ChronyThreadSet::subscribe_to_chronyd()
     int record_index = 0;
     if(stopThread)
         return CHRONY_OK;
+    if(session == nullptr)
+        return CHRONY_INVALID_ARGUMENT;
     chrony_err r = chrony_request_record(session, "sources", record_index);
     if(r != CHRONY_OK)
         return r;


### PR DESCRIPTION
Improve the connection handling mechanism in the Chrony connection manager by tracking connection status more explicitly and restructuring the reconnection logic for better reliability.

This patch:
- Adds a lost_connection flag to explicitly track connection state
- Improves initial connection error handling
- Prevents subscription attempts and lead to proxy crash when there is no active connection
- Makes error messages more specific to differentiate between initial connection failures and connection loss during operation