### PR TITLE
clkmgr: Refactor subscription handling.

### DIFF
--- a/clkmgr/client/timebase_configs.cpp
+++ b/clkmgr/client/timebase_configs.cpp
@@ -125,6 +125,10 @@ void TimeBaseConfigurations::addTimeBaseCfg(const TimeBaseCfg &cfg)
     if(cfg.interfaceName[0] != 0)
         r.setPtp(PTPCfg(cfg.interfaceName, cfg.transportSpecific,
                 cfg.domainNumber));
+    if(cfg.haveSys)
+        r.m_have_sys = true;
+    if(cfg.havePtp)
+        r.m_have_ptp = true;
     getInstWr().m_cfgs[cfg.timeBaseIndex] = std::move(r);
 }
 const TimeBaseRecord &TimeBaseConfigurations::getRecord(size_t timeBaseIndex)

--- a/clkmgr/common/timebase.hpp
+++ b/clkmgr/common/timebase.hpp
@@ -33,6 +33,8 @@ struct TimeBaseCfg {
     char interfaceName[STRING_SIZE_MAX]; /**< Network interface name */
     uint8_t transportSpecific; /**< Transport specific for ptp4l */
     uint8_t domainNumber; /**< Domain number for ptp4l */
+    bool haveSys = false; /**< Flag indicating if system clock is used */
+    bool havePtp = false; /**< Flag to indicate if PTP is configured */
 };
 
 __CLKMGR_NAMESPACE_END

--- a/clkmgr/proxy/config_parser.cpp
+++ b/clkmgr/proxy/config_parser.cpp
@@ -111,6 +111,7 @@ bool JsonConfigParser::process_json(const char *file)
             row.udsAddrPtp4l = "/var/run/ptp4l";
             config.domainNumber = 0;
             config.transportSpecific = 1;
+            config.havePtp = true;
             if(!get_Str_Val(ptp4lObj, "interfaceName", config.interfaceName) ||
                 !get_Str_Val(ptp4lObj, "udsAddr", row.udsAddrPtp4l) ||
                 !get_Int_Val(ptp4lObj, "domainNumber", config.domainNumber) ||
@@ -120,6 +121,7 @@ bool JsonConfigParser::process_json(const char *file)
         }
         if(chronyObj != nullptr) {
             row.udsAddrChrony = "/var/run/chrony/chronyd.sock";
+            config.haveSys = true;
             if(!get_Str_Val(chronyObj, "udsAddr", row.udsAddrChrony))
                 return false;
         }

--- a/clkmgr/pub/clkmgr/timebase_configs.h
+++ b/clkmgr/pub/clkmgr/timebase_configs.h
@@ -94,9 +94,9 @@ class TimeBaseRecord
   private:
     size_t m_index = 0; /**< Index of the time base */
     std::string m_name; /**< Name of the time base */
-    bool m_have_ptp = true; /**< does this time base use PTP */
+    bool m_have_ptp = false; /**< does this time base use PTP */
     PTPCfg m_ptp; /**< PTP configuration */
-    bool m_have_sys = true; /**< does this time base sync the system clock? */
+    bool m_have_sys = false; /**< does this time base sync the system clock? */
 
   protected:
     /** @cond internal */

--- a/clkmgr/sample/clkmgr_test.cpp
+++ b/clkmgr/sample/clkmgr_test.cpp
@@ -96,6 +96,7 @@ int main(int argc, char *argv[])
     SysClockSubscription chronySub;
 
     uint64_t gmClockUUID;
+    std::map<size_t, ClockSyncSubscription> overallSub;
 
     while ((option = getopt(argc, argv, "aps:c:u:l:i:t:n:m:h")) != -1) {
         switch (option) {
@@ -219,6 +220,12 @@ int main(int argc, char *argv[])
             std::cout << "interfaceName: " << cfg.ptp().ifName() << "\n";
             std::cout << "transportSpecific: " << static_cast<int>(cfg.ptp().transportSpecific()) << "\n";
             std::cout << "domainNumber: " << static_cast<int>(cfg.ptp().domainNumber()) << "\n\n";
+            overallSub[cfg.index()].enablePtpSubscription();
+            overallSub[cfg.index()].setPtpSubscription(ptp4lSub);
+        }
+        if(cfg.haveSysClock()) {
+            overallSub[cfg.index()].enableSysSubscription();
+            overallSub[cfg.index()].setSysSubscription(chronySub);
         }
     }
 
@@ -249,13 +256,8 @@ int main(int argc, char *argv[])
     }
 
     for (const auto &idx : index) {
-        ClockSyncSubscription overallSub;
-        overallSub.enablePtpSubscription();
-        overallSub.enableSysSubscription();
-        overallSub.setPtpSubscription(ptp4lSub);
-        overallSub.setSysSubscription(chronySub);
         std::cout << "Subscribe to time base index: " << idx << "\n";
-        if (!cm.subscribe(overallSub, idx, clockSyncData)) {
+        if (!cm.subscribe(overallSub[idx], idx, clockSyncData)) {
             std::cerr << "[clkmgr] Failure in subscribing to clkmgr Proxy !!!\n";
             cm.disconnect();
             return EXIT_FAILURE;

--- a/clkmgr/utest/timebase_configs.cpp
+++ b/clkmgr/utest/timebase_configs.cpp
@@ -24,14 +24,18 @@ class clkmgr::ClientConnectMessage
             .timeBaseName = { 'm', 'e', 0 },
             .interfaceName = { 'e', 't', 'h', '0', 0 },
             .transportSpecific = 4,
-            .domainNumber = 1
+            .domainNumber = 1,
+            .haveSys = true,
+            .havePtp = true
         });
         cfg.addTimeBaseCfg({
             .timeBaseIndex = 2,
             .timeBaseName = { 't', 'o', 'o', 0 },
             .interfaceName = { 'e', 't', 'h', '1', 0 },
             .transportSpecific = 5,
-            .domainNumber = 5
+            .domainNumber = 5,
+            .haveSys = true,
+            .havePtp = false
         });
     }
 };


### PR DESCRIPTION
<h1>Suggested PR Title - Enhance Clock Subscription Management and Configuration Flags Handling in clkmgr</h1>
This commit refactors the handling of clock subscriptions by introducing a vector of `ClockSyncSubscription` objects, allowing for more flexible and scalable management of subscriptions.
- Added `haveSys` and `havePtp` flags to `TimeBaseCfg` to track system and PTP configurations.
- Updated `TimeBaseConfigurations::addTimeBaseCfg` to set `m_have_sys` and `m_have_ptp` based on the new flags.
- Modified `JsonConfigParser::process_json` to correctly set `haveSys` and `havePtp` flags during configuration parsing.
- Changed `TimeBaseRecord` default values for `m_have_ptp` and `m_have_sys` to `false` to reflect the new configuration logic.
- Introduced a vector `overallSub` in `clkmgr_test.cpp` to store `ClockSyncSubscription` objects, replacing previous individual subscription handling.
- Updated logic to populate and manage subscriptions using the vector, including enabling and setting PTP and system subscriptions based on configuration.
- Improved output to reflect the new subscription management approach.

Tested functionality working fine:
![image](https://github.com/user-attachments/assets/50b1559b-ecd6-4fc5-9d3f-6626d8203c6a)

<h1 style='color: red;'>${\color{red}DO \space NOT \space EDIT \space ANYTHING}$</h1>

### Smart DevOps AI Agent for GitHub: Release Version: v1.2-ww18-2025


>### Start of generated PR Summary by Smart DevOps Agent for GitHub

## Types of major changes in the pull request
code_enhancement, feature_enhancement


___

## Pull request change summary
- Added haveSys and havePtp flags to TimeBaseCfg to indicate system and PTP clock configurations.
- Enhanced TimeBaseConfigurations::addTimeBaseCfg to utilize these new flags for setting m_have_sys and m_have_ptp.
- Updated JsonConfigParser::process_json to correctly set these flags based on JSON configuration.
- Refactored clkmgr_test.cpp to manage clock subscriptions using a vector, improving flexibility and scalability.
- Adjusted default values for m_have_ptp and m_have_sys in TimeBaseRecord to false to reflect the new logic.


___

## High level Pull Request Summary
<table><thead><tr><th>Filename&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Summary of changes&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Link to file&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody>
<tr>
  <td><strong>clkmgr/client/timebase_configs.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Enhanced TimeBaseConfigurations::addTimeBaseCfg to set flags <br>m_have_sys and m_have_ptp based on the new haveSys and <br>havePtp flags from TimeBaseCfg. <br><br> Type of change: <br>Feature Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/231/files#diff-d5e45366243d7af4a6ede88041fdbad216378dc7846887b19ec4922b7f9c2bb9"> +4/-0</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/common/timebase.hpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added haveSys and havePtp boolean flags to the TimeBaseCfg <br>struct to indicate the configuration of system and PTP <br>clocks. <br><br> Type of change: Feature Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/231/files#diff-dd697bc5ac3f9c527f4e83ea3f52c9306e5da48cdaf3b25b7082a1c9f70dd538"> +3/-0</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/proxy/config_parser.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated JsonConfigParser::process_json to set haveSys and <br>havePtp flags in TimeBaseCfg based on the presence of <br>respective configurations in the JSON input. <br><br> Type <br>of change: Feature Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/231/files#diff-0a98bee689420ff44901c52def6b7f198e2ff2fc53fe5e452152b764c23a1843"> +2/-0</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/sample/clkmgr_test.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Refactored subscription management in main function by using <br>a vector overallSub to handle ClockSyncSubscription objects <br>dynamically based on the configuration. <br><br> Type of <br>change: Feature Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/231/files#diff-39d8863e2f42d4a016139a23a804368bc9d910f36a372ee321de5dd51f85697e"> +20/-17</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/pub/clkmgr/timebase_configs.h</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Changed default values of m_have_ptp and m_have_sys in <br>TimeBaseRecord to false to align with the new configuration <br>logic. <br><br> Type of change: Code Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/231/files#diff-00e376ca93ec51f3a84cc0dfa543b719fe3f4ed2246811c158abf8ae62627460"> +2/-2</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

>### End of generated PR Summary by Smart DevOps Agent for GitHub