### PR TITLE
clkmgr: add unit test for subscribe and notification msg

### DIFF
--- a/clkmgr/utest/Makefile
+++ b/clkmgr/utest/Makefile
@@ -19,7 +19,7 @@ CLKMGR_COMMON_SRC:=buffer
 CLKMGR_COMMON_OBJS:=$(foreach n,$(CLKMGR_COMMON_SRC),$(CLKMGR_UTEST_DIR)/$n.o)
 
 CLKMGR_MSG_UTEST:=$(CLKMGR_UTEST_DIR)/utest_message
-CLKMGR_MSG_SRC:=connect_msg
+CLKMGR_MSG_SRC:=connect_msg subscribe_msg notification_msg
 CLKMGR_MSG_UTEST_OBJS:=$(foreach n,$(CLKMGR_MSG_SRC),$(CLKMGR_UTEST_DIR)/$n.o)
 CLKMGR_MSG_SRCS:=$(wildcard $(CLKMGR_DIR)/*/*_msg.cpp)
 CLKMGR_MSG_OBJS:=$(CLKMGR_MSG_SRCS:.cpp=.o)

--- a/clkmgr/utest/connect_msg.cpp
+++ b/clkmgr/utest/connect_msg.cpp
@@ -51,23 +51,6 @@ void TimeBaseConfigurations::addTimeBaseCfg(const struct TimeBaseCfg &cfg)
 }
 bool ClientState::connectReply(sessionId_t sessionId) { return sessionId == 14; }
 
-// For other messages
-bool Client::subscribe(size_t timeBaseIndex, sessionId_t sessionId) { return true; }
-void Client::getPTPEvent(size_t timeBaseIndex, ptp_event &evnt) { }
-bool TimeBaseStates::subscribe(size_t timeBaseIndex,
-    const ClockSyncSubscription &newSub)
-{
-    return true;
-}
-bool TimeBaseStates::subscribeReply(size_t timeBaseIndex, const ptp_event &data)
-{
-    return true;
-}
-void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
-    const ptp_event &event)
-{
-}
-
 // For linking
 Transmitter *Transmitter::getTransmitterInstance(sessionId_t sessionId)
 {

--- a/clkmgr/utest/notification_msg.cpp
+++ b/clkmgr/utest/notification_msg.cpp
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+   SPDX-FileCopyrightText: Copyright © 2025 Intel Corporation. */
+
+/** @file
+ * @brief test internal notification message
+ *
+ * @author Lai Peter Jun Ann <peter.jun.ann.lai@@intel.com>
+ * @copyright © 2025 Intel Corporation.
+ *
+ */
+
+#include "client/notification_msg.hpp"
+#include "client/timebase_state.hpp"
+#include "proxy/notification_msg.hpp"
+
+using namespace clkmgr;
+
+static ptp_event ptp_data;
+void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
+    const ptp_event &newEvent)
+{
+    ptp_data = newEvent;
+}
+
+TEST(NotificationMessage, toProxy)
+{
+    // We use the listener buffer
+    Buffer &buf = Listener::getSingleListenerInstance().getBuff();
+    // Set notification message for transmission
+    ClientNotificationMessage cmsg;
+    EXPECT_EQ(cmsg.get_msgId(), NOTIFY_MESSAGE);
+    cmsg.set_sessionId(65535);
+    EXPECT_STREQ(cmsg.toString().c_str(),
+        "get_msgId(): 2\n"
+        "m_msgAck: 0\n");
+    // Build message for transmission
+    EXPECT_TRUE(cmsg.makeBuffer(buf));
+    // Register the proxy side
+    reg_message_type<ProxyNotificationMessage>();
+    // Perpare buffer for parsing
+    buf.setLen(buf.getOffset());
+    // Parse send message
+    Message *msg = Message::parseBuffer(buf);
+    ASSERT_NE(msg, nullptr);
+    std::unique_ptr<Message> send_msg(msg);
+    ProxyNotificationMessage *ppmsg = dynamic_cast<ProxyNotificationMessage *>(msg);
+    ASSERT_NE(ppmsg, nullptr);
+    // Check received notification message
+    EXPECT_EQ(ppmsg->get_msgId(), NOTIFY_MESSAGE);
+    EXPECT_EQ(ppmsg->get_sessionId(), 65535);
+    EXPECT_STREQ(ppmsg->toString().c_str(),
+        "get_msgId(): 2\n"
+        "m_msgAck: 0\n");
+    // Build reply message
+    EXPECT_TRUE(ppmsg->makeBuffer(buf));
+    // Register the client side
+    reg_message_type<ClientNotificationMessage>();
+    // Perpare buffer for parsing
+    buf.setLen(buf.getOffset());
+    // Parse reply
+    msg = Message::parseBuffer(buf);
+    ASSERT_NE(msg, nullptr);
+    send_msg.reset(msg);
+    ClientNotificationMessage *pcmsg = dynamic_cast<ClientNotificationMessage *>
+        (msg);
+    // Check received reply message
+    ASSERT_NE(pcmsg, nullptr);
+    EXPECT_EQ(pcmsg->get_msgId(), NOTIFY_MESSAGE);
+    EXPECT_EQ(pcmsg->get_sessionId(), 65535);
+    EXPECT_STREQ(pcmsg->toString().c_str(),
+        "get_msgId(): 2\n"
+        "m_msgAck: 0\n");
+    EXPECT_TRUE(ptp_data.as_capable);
+    EXPECT_EQ(ptp_data.chrony_offset, 123);
+    EXPECT_EQ(ptp_data.chrony_reference_id, 456);
+    EXPECT_EQ(ptp_data.gm_identity[0], 1);
+    EXPECT_EQ(ptp_data.master_offset, 12);
+    EXPECT_EQ(ptp_data.polling_interval, 500000);
+    EXPECT_EQ(ptp_data.ptp4l_sync_interval, 10000);
+    EXPECT_FALSE(ptp_data.synced_to_primary_clock);
+}

--- a/clkmgr/utest/subscribe_msg.cpp
+++ b/clkmgr/utest/subscribe_msg.cpp
@@ -1,0 +1,110 @@
+/* SPDX-License-Identifier: BSD-3-Clause
+   SPDX-FileCopyrightText: Copyright © 2025 Intel Corporation. */
+
+/** @file
+ * @brief test internal subscribe message
+ *
+ * @author Lai Peter Jun Ann <peter.jun.ann.lai@@intel.com>
+ * @copyright © 2025 Intel Corporation.
+ *
+ */
+
+#include "client/subscribe_msg.hpp"
+#include "client/timebase_state.hpp"
+#include "proxy/subscribe_msg.hpp"
+#include "proxy/client.hpp"
+
+using namespace clkmgr;
+
+// Used on ProxySubscribeMessage::parseBufferTail()
+bool Client::subscribe(size_t timeBaseIndex, sessionId_t sessionId)
+{
+    return true;
+}
+
+// ProxySubscribeMessage::makeBufferTail
+void Client::getPTPEvent(size_t timeBaseIndex, ptp_event &event)
+{
+    event.as_capable = true;
+    event.chrony_offset = 123;
+    event.chrony_reference_id = 456;
+    event.gm_identity[0] = 1;
+    event.master_offset = 12;
+    event.polling_interval = 500000;
+    event.ptp4l_sync_interval = 10000;
+    event.synced_to_primary_clock = false;
+}
+
+// For other messages
+bool TimeBaseStates::subscribe(size_t timeBaseIndex,
+    const ClockSyncSubscription &newSub)
+{
+    return true;
+}
+
+static ptp_event ptp_data;
+bool TimeBaseStates::subscribeReply(size_t timeBaseIndex, const ptp_event &data)
+{
+    ptp_data = data;
+    return true;
+}
+
+TEST(SubscribeMessage, toProxy)
+{
+    // We use the listener buffer
+    Buffer &buf = Listener::getSingleListenerInstance().getBuff();
+    // Set subscribe message for transmission
+    ClientSubscribeMessage cmsg;
+    EXPECT_EQ(cmsg.get_msgId(), SUBSCRIBE_MSG);
+    cmsg.set_sessionId(12);
+    EXPECT_STREQ(cmsg.toString().c_str(),
+        "clkmgr::SubscribeMessage\n"
+        "get_msgId(): 1\n"
+        "m_msgAck: 0\n");
+    // Build message for transmission
+    EXPECT_TRUE(cmsg.makeBuffer(buf));
+    // Register the proxy side
+    reg_message_type<ProxySubscribeMessage>();
+    // Perpare buffer for parsing
+    buf.setLen(buf.getOffset());
+    // Parse send message
+    Message *msg = Message::parseBuffer(buf);
+    ASSERT_NE(msg, nullptr);
+    std::unique_ptr<Message> send_msg(msg);
+    ProxySubscribeMessage *ppmsg = dynamic_cast<ProxySubscribeMessage *>(msg);
+    ASSERT_NE(ppmsg, nullptr);
+    // Check received subscribe message
+    EXPECT_EQ(ppmsg->get_msgId(), SUBSCRIBE_MSG);
+    EXPECT_EQ(ppmsg->get_sessionId(), 12);
+    EXPECT_STREQ(ppmsg->toString().c_str(),
+        "clkmgr::SubscribeMessage\n"
+        "get_msgId(): 1\n"
+        "m_msgAck: 1\n");
+    // Build reply message
+    EXPECT_TRUE(ppmsg->makeBuffer(buf));
+    // Register the client side
+    reg_message_type<ClientSubscribeMessage>();
+    // Perpare buffer for parsing
+    buf.setLen(buf.getOffset());
+    // Parse reply
+    msg = Message::parseBuffer(buf);
+    ASSERT_NE(msg, nullptr);
+    send_msg.reset(msg);
+    ClientSubscribeMessage *pcmsg = dynamic_cast<ClientSubscribeMessage *>(msg);
+    // Check received reply message
+    ASSERT_NE(pcmsg, nullptr);
+    EXPECT_EQ(pcmsg->get_msgId(), SUBSCRIBE_MSG);
+    EXPECT_EQ(pcmsg->get_sessionId(), 12);
+    EXPECT_STREQ(pcmsg->toString().c_str(),
+        "clkmgr::SubscribeMessage\n"
+        "get_msgId(): 1\n"
+        "m_msgAck: 0\n");
+    EXPECT_TRUE(ptp_data.as_capable);
+    EXPECT_EQ(ptp_data.chrony_offset, 123);
+    EXPECT_EQ(ptp_data.chrony_reference_id, 456);
+    EXPECT_EQ(ptp_data.gm_identity[0], 1);
+    EXPECT_EQ(ptp_data.master_offset, 12);
+    EXPECT_EQ(ptp_data.polling_interval, 500000);
+    EXPECT_EQ(ptp_data.ptp4l_sync_interval, 10000);
+    EXPECT_FALSE(ptp_data.synced_to_primary_clock);
+}


### PR DESCRIPTION
Add unit test for subscribe_msg and notification_msg.

![image](https://github.com/user-attachments/assets/bc7fbbfd-1808-42cf-b646-128f5d646350)
