### PR TITLE
Add Erez's patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,8 +295,8 @@ SRC_FILES_DIR:=$(wildcard README.md t*/*.pl */*/*.m4 .reuse/* */gitlab*\
   $(HEADERS_SRCS_CLKMGR)
 ifeq ($(INSIDE_GIT),true)
 SRC_FILES!=git ls-files $(foreach n,archlinux debian rpm sample gentoo\
-  utest/*.[chj]* uctest/*.[ch]* .github .gitlab clkmgr/sample\
-  clkmgr/utest/*.[ch]*,':!/:$n')\
+  utest/*.[chj]* uctest/*.[ch]* .github .gitlab $(CLKMGR_DIR)/sample\
+  $(CLKMGR_DIR)/utest/*.cpp,':!/:$n')\
   ':!:*.gitignore' ':!*/*/test.*' ':!*/*/clkmgr_test.*' ':!*/*/utest.*'
 GIT_ROOT!=git rev-parse --show-toplevel
 ifeq ($(GIT_ROOT),$(CURDIR))

--- a/clkmgr/Makefile
+++ b/clkmgr/Makefile
@@ -76,7 +76,7 @@ $(CLKMGR_PROXY): $(CLKMGR_COMMON_OBJS) $(CLKMGR_PROXY_OBJS) $(LIB_NAME_SO) |\
 
 ALL+=$(CLKMGR_LIB_LA) $(CLKMGR_PROXY)
 
-include clkmgr/utest/Makefile
+include $(CLKMGR_DIR)/utest/Makefile
 
 define clkmgr_pkgconfig
 $(hash) $(SPDXLI) $(SPDXBSD3)

--- a/clkmgr/TEST_clkmgr.md
+++ b/clkmgr/TEST_clkmgr.md
@@ -227,15 +227,15 @@ Options:
   -p enable user to subscribe to specific time base indices  
   -s subscribe_event_mask  
      Default: 0xf  
-     Bit 0: eventGMOffset  
-     Bit 1: eventSyncedToGM  
-     Bit 2: eventASCapable  
-     Bit 3: eventGMChanged  
+     Bit 0: EventGMOffset  
+     Bit 1: EventSyncedToGM  
+     Bit 2: EventASCapable  
+     Bit 3: EventGMChanged  
   -c composite_event_mask  
      Default: 0x7  
-     Bit 0: eventGMOffset  
-     Bit 1: eventSyncedToGM  
-     Bit 2: eventASCapable  
+     Bit 0: EventGMOffset  
+     Bit 1: EventSyncedToGM  
+     Bit 2: EventASCapable  
   -u gm offset upper limit (ns)  
      Default: 100000 ns  
   -l gm offset lower limit (ns)  

--- a/clkmgr/client/clkmgr.i
+++ b/clkmgr/client/clkmgr.i
@@ -47,10 +47,16 @@
 /* From /usr/share/swig././ */
 %include <std_string.i>
 %include <std_vector.i>
-%apply uint16_t { sessionId_t };
+%apply unsigned long { time_t };
 
 /* warning definitions per language */
 %include "warn.i"
+
+/* C++ 11 time structure */
+struct timespec {
+    time_t tv_sec;
+    long tv_nsec;
+};
 
 /* library code */
 %include "pub/clockmanager.h"

--- a/clkmgr/client/clockmanager.cpp
+++ b/clkmgr/client/clockmanager.cpp
@@ -155,7 +155,7 @@ static inline int _statusWait(int timeout, size_t timeBaseIndex,
     auto &states = TimeBaseStates::getInstance();
     if(!states.getSubscribed(timeBaseIndex)) {
         PrintDebug("[WAIT] Invalid timeBaseIndex.");
-        return false;
+        return 0;
     }
     auto start = high_resolution_clock::now();
     auto end = (timeout == -1) ?  time_point<high_resolution_clock>::max() :

--- a/clkmgr/client/clockmanager_c.cpp
+++ b/clkmgr/client/clockmanager_c.cpp
@@ -50,14 +50,10 @@ bool clkmgr_subscribe(const Clkmgr_Subscription *sub_c,
         return false;
     // Create a C++ subscription object and set its parameters from the C struct
     ClockSyncSubscription newSub;
-    if(clkmgr_isSubscriptionEnabled(sub_c, Clkmgr_PTPClock)) {
+    if(clkmgr_isSubscriptionEnabled(sub_c, Clkmgr_PTPClock))
         newSub.setPtpSubscription(*sub_c->ptp);
-        newSub.enablePtpSubscription();
-    }
-    if(clkmgr_isSubscriptionEnabled(sub_c, Clkmgr_SysClock)) {
+    if(clkmgr_isSubscriptionEnabled(sub_c, Clkmgr_SysClock))
         newSub.setSysSubscription(*sub_c->sys);
-        newSub.enableSysSubscription();
-    }
     return ClockManager::subscribe(newSub, timeBaseIndex, *data_c->data);
 }
 

--- a/clkmgr/client/subscription.cpp
+++ b/clkmgr/client/subscription.cpp
@@ -73,7 +73,8 @@ ClockSyncSubscription::ClockSyncSubscription()
         return nm##Subscribed; }\
     void ClockSyncSubscription::set##Nm##Subscription(\
         const NM##ClockSubscription &_o) {\
-        nm##Subscription = _o; }\
+        nm##Subscription = _o;\
+        nm##Subscribed = true;}\
     const NM##ClockSubscription &ClockSyncSubscription::\
     get##Nm##Subscription() const {\
         return nm##Subscription; }
@@ -191,8 +192,7 @@ extern "C" {
         }
     }
 
-    bool clkmgr_enableSubscription(Clkmgr_Subscription *sub_c,
-        uint32_t clock_type)
+    bool clkmgr_enableSubscription(Clkmgr_Subscription *sub_c, uint32_t clock_type)
     {
         if(!sub_c)
             return false;
@@ -208,8 +208,7 @@ extern "C" {
         }
     }
 
-    bool clkmgr_disableSubscription(Clkmgr_Subscription *sub_c,
-        uint32_t clock_type)
+    bool clkmgr_disableSubscription(Clkmgr_Subscription *sub_c, uint32_t clock_type)
     {
         if(!sub_c)
             return false;

--- a/clkmgr/client/subscription.cpp
+++ b/clkmgr/client/subscription.cpp
@@ -30,7 +30,7 @@ GET(PTPClockSubscription, uint32_t,
 
 bool ClockSubscriptionBase::setEventMask(uint32_t newEventMask)
 {
-    if(newEventMask >= eventLast) {
+    if(newEventMask >= EventLast) {
         PrintDebug("Event mask contains invalid bits.");
         return false;
     }

--- a/clkmgr/client/timebase_state.cpp
+++ b/clkmgr/client/timebase_state.cpp
@@ -153,8 +153,8 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
     // Get the current state of the timebase
     PTPClockEvent ptp4lEventState = state.get_ptp4lEventState();
     SysClockEvent chronyEventState = state.get_chronyEventState();
-    // Update eventGMOffset
-    if((ptpEventSub & eventGMOffset) &&
+    // Update EventGMOffset
+    if((ptpEventSub & EventGMOffset) &&
         (newEvent.master_offset != ptp4lEventState.getClockOffset())) {
         ptpClockEventHandler.setClockOffset(ptp4lEventState,
             newEvent.master_offset);
@@ -176,8 +176,8 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
             }
         }
     }
-    // Update eventSyncedToGM
-    if((ptpEventSub & eventSyncedToGM) &&
+    // Update EventSyncedToGM
+    if((ptpEventSub & EventSyncedToGM) &&
         (newEvent.synced_to_primary_clock !=
             ptp4lEventState.isSyncedWithGm())) {
         ptpClockEventHandler.setSyncedWithGm(ptp4lEventState,
@@ -186,14 +186,14 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
             ptp4lEventState.getSyncedWithGmEventCount() + 1);
         state.set_event_changed(true);
     }
-    // Update eventGMChanged
+    // Update EventGMChanged
     uint64_t sourceClockUUID = ptp4lEventState.getGmIdentity();
     uint8_t sourceClockUUIDBytes[8];
     for(int i = 0; i < 8; ++i) {
         sourceClockUUIDBytes[i] =
             static_cast<uint8_t>(sourceClockUUID >>(8 * (7 - i)));
     }
-    if((ptpEventSub & eventGMChanged) &&
+    if((ptpEventSub & EventGMChanged) &&
         (memcmp(sourceClockUUIDBytes, newEvent.gm_identity,
                 sizeof(newEvent.gm_identity)) != 0)) {
         uint64_t identity = 0;
@@ -207,8 +207,8 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
             ptp4lEventState.getGmChangedEventCount() + 1);
         state.set_event_changed(true);
     }
-    // Update eventASCapable
-    if((ptpEventSub & eventASCapable) &&
+    // Update EventASCapable
+    if((ptpEventSub & EventASCapable) &&
         (newEvent.as_capable != ptp4lEventState.isAsCapable())) {
         ptpClockEventHandler.setAsCapable(ptp4lEventState, newEvent.as_capable);
         ptpClockEventHandler.setAsCapableEventCount(ptp4lEventState,
@@ -217,11 +217,11 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
     }
     // Update composite event
     bool composite_event = true;
-    if(ptpCompositeEventSub & eventGMOffset)
+    if(ptpCompositeEventSub & EventGMOffset)
         composite_event &= ptp4lEventState.isOffsetInRange();
-    if(ptpCompositeEventSub & eventSyncedToGM)
+    if(ptpCompositeEventSub & EventSyncedToGM)
         composite_event &= ptp4lEventState.isSyncedWithGm();
-    if(ptpCompositeEventSub & eventASCapable)
+    if(ptpCompositeEventSub & EventASCapable)
         composite_event &= ptp4lEventState.isAsCapable();
     if(ptpCompositeEventSub &&
         (composite_event != ptp4lEventState.isCompositeEventMet())) {

--- a/clkmgr/common/msgq_tport.hpp
+++ b/clkmgr/common/msgq_tport.hpp
@@ -20,7 +20,7 @@
 
 __CLKMGR_NAMESPACE_BEGIN
 
-static const size_t MAX_BUFFER_LENGTH = 4096;
+static const size_t MAX_BUFFER_LENGTH = 8192;
 static const std::string mqProxyName("/clkmgr");
 
 class Buffer
@@ -72,7 +72,7 @@ class Queue
     // Delete Copy Assignment Operator
     Queue &operator=(const Queue &) = delete;
     // Receive POSIX message queue
-    bool RxOpen(const std::string &name, size_t maxMsg);
+    bool RxOpen(const std::string &name, size_t maxMsg, bool allRx = false);
     // Transmit POSIX message queue
     bool TxOpen(const std::string &name, bool block = true);
     // Is the queue exist
@@ -113,7 +113,7 @@ class Listener : public Buffer, public End
   public:
     static Listener &getSingleListenerInstance();
     virtual ~Listener() = default;
-    bool init(const std::string &name, size_t maxMsg);
+    bool init(const std::string &name, size_t maxMsg, bool allRx = false);
     void dispatchLoop();
     bool MqListenerWork();
     Buffer &getBuff() { return *this; }

--- a/clkmgr/common/types.m4
+++ b/clkmgr/common/types.m4
@@ -28,23 +28,23 @@ ns_s()
 
 /**
  * Bitmask of events available for subscription. Each bit represents one event.
- * @note The eventLast is reserved for future use.
+ * @note The Nm(EventLast) is reserved for future use.
  */
 enum Nm(EventIndex) sz(`: uint32_t '){
     /** Offset between primary and secondary clock */
-    Nm(eventGMOffset) = 1 << 0,
+    Nm(EventGMOffset) = 1 << 0,
     /** Secondary clock is synced to primary clock */
-    Nm(eventSyncedToGM) = 1 << 1,
-    Nm(eventASCapable) = 1 << 2, /**< Link Partner is IEEE 802.1AS capable */
-    Nm(eventGMChanged) = 1 << 3, /**< UUID of primary clock is changed */
-    Nm(eventLast) = 1 << 4 /**< Last event */
+    Nm(EventSyncedToGM) = 1 << 1,
+    Nm(EventASCapable) = 1 << 2, /**< Link Partner is IEEE 802.1AS capable */
+    Nm(EventGMChanged) = 1 << 3, /**< UUID of primary clock is changed */
+    Nm(EventLast) = 1 << 4 /**< Last event */
 };
 
 /**
  * All the events that can be used as conditions for satisfying the composite event.
  */
-cnst(uint32_t,COMPOSITE_EVENT_ALL,Nm(eventGMOffset) | \
-    Nm(eventSyncedToGM) | Nm(eventASCapable))
+cnst(uint32_t,COMPOSITE_EVENT_ALL,Nm(EventGMOffset) | \
+    Nm(EventSyncedToGM) | Nm(EventASCapable))
 
 /**
  * Maximum number of events that can have user predefined threshold

--- a/clkmgr/proxy/client.cpp
+++ b/clkmgr/proxy/client.cpp
@@ -175,14 +175,14 @@ Client *Client::getClient(sessionId_t sessionId)
     return sessionMap.count(sessionId) > 0 ? sessionMap[sessionId].get() : nullptr;
 }
 
-bool Client::init()
+bool Client::init(bool useMsgQAllAccess)
 {
     // Register messages we recieve from client side
     reg_message_type<ProxyConnectMessage, ProxySubscribeMessage>();
     // ProxyNotificationMessage - Proxy send it only, never send from client
     Listener &rx = Listener::getSingleListenerInstance();
     PrintDebug("Initializing Proxy listener Queue ...");
-    if(!rx.init(mqProxyName, MAX_CLIENT_COUNT)) {
+    if(!rx.init(mqProxyName, MAX_CLIENT_COUNT, useMsgQAllAccess)) {
         PrintError("Initializing Proxy listener queue failed");
         return false;
     }

--- a/clkmgr/proxy/client.hpp
+++ b/clkmgr/proxy/client.hpp
@@ -80,7 +80,7 @@ class Client
     friend class ClientRemoveAll;
 
   public:
-    static bool init();
+    static bool init(bool useMsgQAllAccess);
     static sessionId_t connect(sessionId_t sessionId, const std::string &id);
     static bool subscribe(size_t timeBaseIndex, sessionId_t sessionId);
     static void NotifyClients(size_t timeBaseIndex);

--- a/clkmgr/proxy/clkmgr-proxy.service
+++ b/clkmgr/proxy/clkmgr-proxy.service
@@ -10,7 +10,7 @@ After=network.target auditd.service
 ConditionPathExists=!/etc/clkmgr/proxy_not_to_be_run
 
 [Service]
-ExecStart=/usr/sbin/clkmgr_proxy -f /etc/clkmgr/proxy_cfg.json -q 1 -s 1
+ExecStart=/usr/sbin/clkmgr_proxy -f /etc/clkmgr/proxy_cfg.json -q 1 -s 1 -a 1
 KillMode=process
 Restart=on-failure
 Type=exec

--- a/clkmgr/proxy/clkmgr-proxy.socket
+++ b/clkmgr/proxy/clkmgr-proxy.socket
@@ -10,5 +10,11 @@ ConditionPathExists=!/etc/clkmgr/proxy_not_to_be_run
 [Socket]
 ListenMessageQueue=/clkmgr
 Accept=no
+ReceiveBuffer=8K
+SendBuffer=8K
+
+[Install]
+WantedBy=multi-user.target
+Alias=clkmgr-proxy.socket
 
 # vi: set ft=systemd:

--- a/clkmgr/proxy/main.cpp
+++ b/clkmgr/proxy/main.cpp
@@ -30,6 +30,8 @@ static inline int help(FILE *out, const char *me, int ret)
         "Usage of %s:\n"
         "Options:\n"
         " -f [file] Read configuration from 'file'\n"
+        " -a <0|1> Open message queue in access all mode\n"
+        "          0: disable(default), 1: enable\n"
         " -l <lvl> Set log level\n"
         "          0: ERROR, 1: INFO(default), 2: DEBUG, 3: TRACE\n"
         " -q <0|1> Enable or disable quiet mode\n"
@@ -47,12 +49,13 @@ int main(int argc, char *argv[])
     int level, opt;
     bool useSyslog = false; // Default value
     bool useVerbode = true; // Default value
+    bool useMsgQAllAccess = false; // Default value
     const char *file;
     const char *me = strrchr(argv[0], '/');
     // Remove leading path
     me = me == nullptr ? argv[0] : me + 1;
     JsonConfigParser &parser = JsonConfigParser::getInstance();
-    while((opt = getopt(argc, argv, "f:l:q:s:vh")) != -1) {
+    while((opt = getopt(argc, argv, "f:l:q:s:a:vh")) != -1) {
         switch(opt) {
             case 'f':
                 file = optarg;
@@ -75,6 +78,9 @@ int main(int argc, char *argv[])
             case 's':
                 useSyslog = atoi(optarg) != 0;
                 break;
+            case 'a':
+                useMsgQAllAccess = atoi(optarg) != 0;
+                break;
             case 'v':
                 // Print version of compile time!
                 // The actual libptpmgmt library can be newer!
@@ -94,7 +100,7 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
     BlockStopSignal();
-    if(!Client::init()) {
+    if(!Client::init(useMsgQAllAccess)) {
         PrintError("Proxy client init failed");
         return EXIT_FAILURE;
     }

--- a/clkmgr/pub/clkmgr/subscription.h
+++ b/clkmgr/pub/clkmgr/subscription.h
@@ -125,6 +125,7 @@ class ClockSyncSubscription
 
     /**
      * Set the PTP clock subscription with a new PTPClockSubscription object
+     * and enable it
      * @param[in] newPtpSub The new PTPClockSubscription object to update
      */
     void setPtpSubscription(const PTPClockSubscription &newPtpSub);
@@ -153,6 +154,7 @@ class ClockSyncSubscription
 
     /**
      * Set the system clock subscription with a new SysClockSubscription object
+     * and enable it
      * @param[in] newSysSub The new SysClockSubscription object to update
      */
     void setSysSubscription(const SysClockSubscription &newSysSub);

--- a/clkmgr/sample/clkmgr_c_test.c
+++ b/clkmgr/sample/clkmgr_c_test.c
@@ -205,13 +205,11 @@ int main(int argc, char *argv[])
                 clkmgr_setPtpCompositeEventMask(clockSub[i], compositeEventMask);
                 clkmgr_setClockOffsetThreshold(clockSub[i], Clkmgr_PTPClock,
                     ptp4lClockOffsetThreshold);
-                clkmgr_enableSubscription(clockSub[i], Clkmgr_PTPClock);
             }
             if(clkmgr_haveSysClock(i)) {
                 clkmgr_setEventMask(clockSub[i], Clkmgr_SysClock, eventMask);
                 clkmgr_setClockOffsetThreshold(clockSub[i], Clkmgr_SysClock,
                     chronyClockOffsetThreshold);
-                clkmgr_enableSubscription(clockSub[i], Clkmgr_SysClock);
             }
         } else {
             printf("Failed to get time base configuration for index %ld\n", i);

--- a/clkmgr/sample/clkmgr_c_test.c
+++ b/clkmgr/sample/clkmgr_c_test.c
@@ -77,10 +77,10 @@ int main(int argc, char *argv[])
     int retval;
     int option;
 
-    uint32_t eventMask = (Clkmgr_eventGMOffset | Clkmgr_eventSyncedToGM |
-        Clkmgr_eventASCapable | Clkmgr_eventGMChanged);
-    uint32_t compositeEventMask = (Clkmgr_eventGMOffset |
-        Clkmgr_eventSyncedToGM | Clkmgr_eventASCapable);
+    uint32_t eventMask = (Clkmgr_EventGMOffset | Clkmgr_EventSyncedToGM |
+        Clkmgr_EventASCapable | Clkmgr_EventGMChanged);
+    uint32_t compositeEventMask = (Clkmgr_EventGMOffset |
+        Clkmgr_EventSyncedToGM | Clkmgr_EventASCapable);
 
     while ((option = getopt(argc, argv, "aps:c:u:l:i:t:m:n:h")) != -1) {
         switch (option) {
@@ -122,15 +122,15 @@ int main(int argc, char *argv[])
                    "  -p enable user to subscribe to specific time base indices\n"
                    "  -s subscribe_event_mask\n"
                    "     Default: 0x%x\n"
-                   "     Bit 0: eventGMOffset\n"
-                   "     Bit 1: eventSyncedToGM\n"
-                   "     Bit 2: eventASCapable\n"
-                   "     Bit 3: eventGMChanged\n"
+                   "     Bit 0: EventGMOffset\n"
+                   "     Bit 1: EventSyncedToGM\n"
+                   "     Bit 2: EventASCapable\n"
+                   "     Bit 3: EventGMChanged\n"
                    "  -c composite_event_mask\n"
                    "     Default: 0x%x\n"
-                   "     Bit 0: eventGMOffset\n"
-                   "     Bit 1: eventSyncedToGM\n"
-                   "     Bit 2: eventASCapable\n"
+                   "     Bit 0: EventGMOffset\n"
+                   "     Bit 1: EventSyncedToGM\n"
+                   "     Bit 2: EventASCapable\n"
                    "  -l gm offset threshold (ns)\n"
                    "     Default: %d ns\n"
                    "  -i idle time (s)\n"
@@ -152,15 +152,15 @@ int main(int argc, char *argv[])
                    "  -p enable user to subscribe to specific time base indices\n"
                    "  -s subscribe_event_mask\n"
                    "     Default: 0x%x\n"
-                   "     Bit 0: eventGMOffset\n"
-                   "     Bit 1: eventSyncedToGM\n"
-                   "     Bit 2: eventASCapable\n"
-                   "     Bit 3: eventGMChanged\n"
+                   "     Bit 0: EventGMOffset\n"
+                   "     Bit 1: EventSyncedToGM\n"
+                   "     Bit 2: EventASCapable\n"
+                   "     Bit 3: EventGMChanged\n"
                    "  -c composite_event_mask\n"
                    "     Default: 0x%x\n"
-                   "     Bit 0: eventGMOffset\n"
-                   "     Bit 1: eventSyncedToGM\n"
-                   "     Bit 2: eventASCapable\n"
+                   "     Bit 0: EventGMOffset\n"
+                   "     Bit 1: EventSyncedToGM\n"
+                   "     Bit 2: EventASCapable\n"
                    "  -l gm offset threshold (ns)\n"
                    "     Default: %d ns\n"
                    "  -i idle time (s)\n"
@@ -268,19 +268,19 @@ int main(int argc, char *argv[])
         if (eventMask) {
             printf("|---------------------------|------------------------|\n");
         }
-        if (eventMask & Clkmgr_eventGMOffset) {
+        if (eventMask & Clkmgr_EventGMOffset) {
             printf("| %-25s | %-22d |\n", "offset_in_range",
                 clkmgr_isOffsetInRange(syncData, Clkmgr_PTPClock));
         }
-        if (eventMask & Clkmgr_eventSyncedToGM) {
+        if (eventMask & Clkmgr_EventSyncedToGM) {
             printf("| %-25s | %-22d |\n", "synced_to_primary_clock",
                 clkmgr_isPtpSyncedWithGm(syncData));
         }
-        if (eventMask & Clkmgr_eventASCapable) {
+        if (eventMask & Clkmgr_EventASCapable) {
             printf("| %-25s | %-22d |\n", "as_capable",
                 clkmgr_isPtpAsCapable(syncData));
         }
-        if (eventMask & Clkmgr_eventGMChanged) {
+        if (eventMask & Clkmgr_EventGMChanged) {
             printf("| %-25s | %-22d |\n", "gm_Changed",
                 clkmgr_isGmChanged(syncData, Clkmgr_PTPClock));
         }
@@ -308,13 +308,13 @@ int main(int argc, char *argv[])
             printf("| %-25s | %-22d |\n", "composite_event",
                 clkmgr_isPtpCompositeEventMet(syncData));
         }
-        if (compositeEventMask & Clkmgr_eventGMOffset) {
+        if (compositeEventMask & Clkmgr_EventGMOffset) {
             printf("| - %-23s | %-22s |\n", "offset_in_range", " ");
         }
-        if (compositeEventMask & Clkmgr_eventSyncedToGM) {
+        if (compositeEventMask & Clkmgr_EventSyncedToGM) {
             printf("| - %-19s | %-22s |\n", "synced_to_primary_clock", " ");
         }
-        if (compositeEventMask & Clkmgr_eventASCapable) {
+        if (compositeEventMask & Clkmgr_EventASCapable) {
             printf("| - %-23s | %-22s |\n", "as_capable", " ");
         }
         if (compositeEventMask) {
@@ -371,22 +371,22 @@ int main(int argc, char *argv[])
             if (eventMask) {
             printf("|---------------------------|--------------|-------------|\n");
             }
-            if (eventMask & Clkmgr_eventGMOffset) {
+            if (eventMask & Clkmgr_EventGMOffset) {
                 printf("| %-25s | %-12d | %-11d |\n", "offset_in_range",
                     clkmgr_isOffsetInRange(syncData, Clkmgr_PTPClock),
                     clkmgr_getOffsetInRangeEventCount(syncData, Clkmgr_PTPClock));
             }
-            if (eventMask & Clkmgr_eventSyncedToGM) {
+            if (eventMask & Clkmgr_EventSyncedToGM) {
                 printf("| %-25s | %-12d | %-11d |\n", "synced_to_primary_clock",
                     clkmgr_isPtpSyncedWithGm(syncData),
                     clkmgr_getPtpSyncedWithGmEventCount(syncData));
             }
-            if (eventMask & Clkmgr_eventASCapable) {
+            if (eventMask & Clkmgr_EventASCapable) {
                 printf("| %-25s | %-12d | %-11d |\n", "as_capable",
                     clkmgr_isPtpAsCapable(syncData),
                     clkmgr_getPtpAsCapableEventCount(syncData));
             }
-            if (eventMask & Clkmgr_eventGMChanged) {
+            if (eventMask & Clkmgr_EventGMChanged) {
                 printf("| %-25s | %-12d | %-11d |\n", "gm_Changed",
                     clkmgr_isGmChanged(syncData, Clkmgr_PTPClock),
                     clkmgr_getGmChangedEventCount(syncData, Clkmgr_PTPClock));
@@ -416,13 +416,13 @@ int main(int argc, char *argv[])
                     clkmgr_isPtpCompositeEventMet(syncData),
                     clkmgr_getPtpCompositeEventCount(syncData));
             }
-            if (compositeEventMask & Clkmgr_eventGMOffset) {
+            if (compositeEventMask & Clkmgr_EventGMOffset) {
                 printf("| - %-23s | %-12s | %-11s |\n", "offset_in_range", "", "");
             }
-            if (compositeEventMask & Clkmgr_eventSyncedToGM) {
+            if (compositeEventMask & Clkmgr_EventSyncedToGM) {
                 printf("| - %-19s | %-12s | %-11s |\n", "synced_to_primary_clock", "", "");
             }
-            if (compositeEventMask & Clkmgr_eventASCapable) {
+            if (compositeEventMask & Clkmgr_EventASCapable) {
                 printf("| - %-23s | %-12s | %-11s |\n", "as_capable", "", "");
             }
             if (compositeEventMask) {

--- a/clkmgr/sample/clkmgr_test.cpp
+++ b/clkmgr/sample/clkmgr_test.cpp
@@ -220,13 +220,10 @@ int main(int argc, char *argv[])
             std::cout << "interfaceName: " << cfg.ptp().ifName() << "\n";
             std::cout << "transportSpecific: " << static_cast<int>(cfg.ptp().transportSpecific()) << "\n";
             std::cout << "domainNumber: " << static_cast<int>(cfg.ptp().domainNumber()) << "\n\n";
-            overallSub[cfg.index()].enablePtpSubscription();
             overallSub[cfg.index()].setPtpSubscription(ptp4lSub);
         }
-        if(cfg.haveSysClock()) {
-            overallSub[cfg.index()].enableSysSubscription();
+        if(cfg.haveSysClock())
             overallSub[cfg.index()].setSysSubscription(chronySub);
-        }
     }
 
     if (subscribeAll) {

--- a/clkmgr/sample/clkmgr_test.cpp
+++ b/clkmgr/sample/clkmgr_test.cpp
@@ -80,12 +80,12 @@ int main(int argc, char *argv[])
     int option;
 
     std::uint32_t event2Sub = {
-        (eventGMOffset | eventSyncedToGM | eventASCapable |
-        eventGMChanged)
+        (EventGMOffset | EventSyncedToGM | EventASCapable |
+        EventGMChanged)
     };
 
     std::uint32_t composite_event = {
-        (eventGMOffset | eventSyncedToGM | eventASCapable)
+        (EventGMOffset | EventSyncedToGM | EventASCapable)
     };
 
     ClockSyncData clockSyncData;
@@ -140,15 +140,15 @@ int main(int argc, char *argv[])
                 "  -p enable user to subscribe to specific time base indices\n"
                 "  -s subscribe_event_mask\n"
                 "     Default: 0x" << std::hex << event2Sub << "\n"
-                "     Bit 0: eventGMOffset\n"
-                "     Bit 1: eventSyncedToGM\n"
-                "     Bit 2: eventASCapable\n"
-                "     Bit 3: eventGMChanged\n"
+                "     Bit 0: EventGMOffset\n"
+                "     Bit 1: EventSyncedToGM\n"
+                "     Bit 2: EventASCapable\n"
+                "     Bit 3: EventGMChanged\n"
                 "  -c composite_event_mask\n"
                 "     Default: 0x" << composite_event << "\n"
-                "     Bit 0: eventGMOffset\n"
-                "     Bit 1: eventSyncedToGM\n"
-                "     Bit 2: eventASCapable\n"
+                "     Bit 0: EventGMOffset\n"
+                "     Bit 1: EventSyncedToGM\n"
+                "     Bit 2: EventASCapable\n"
                 "  -l gm offset threshold (ns)\n"
                 "     Default: " << ptp4lClockOffsetThreshold << " ns\n"
                 "  -i idle time (s)\n"
@@ -166,15 +166,15 @@ int main(int argc, char *argv[])
                 "  -p enable user to subscribe to specific time base indices\n"
                 "  -s subscribe_event_mask\n"
                 "     Default: 0x" << std::hex << event2Sub << "\n"
-                "     Bit 0: eventGMOffset\n"
-                "     Bit 1: eventSyncedToGM\n"
-                "     Bit 2: eventASCapable\n"
-                "     Bit 3: eventGMChanged\n"
+                "     Bit 0: EventGMOffset\n"
+                "     Bit 1: EventSyncedToGM\n"
+                "     Bit 2: EventASCapable\n"
+                "     Bit 3: EventGMChanged\n"
                 "  -c composite_event_mask\n"
                 "     Default: 0x" << composite_event << "\n"
-                "     Bit 0: eventGMOffset\n"
-                "     Bit 1: eventSyncedToGM\n"
-                "     Bit 2: eventASCapable\n"
+                "     Bit 0: EventGMOffset\n"
+                "     Bit 1: EventSyncedToGM\n"
+                "     Bit 2: EventASCapable\n"
                 "  -l gm offset threshold (ns)\n"
                 "     Default: " << ptp4lClockOffsetThreshold << " ns\n"
                 "  -i idle time (s)\n"
@@ -272,17 +272,17 @@ int main(int argc, char *argv[])
         if (event2Sub) {
             printf("|---------------------------|------------------------|\n");
         }
-        if (event2Sub & eventGMOffset) {
+        if (event2Sub & EventGMOffset) {
             printf("| %-25s | %-22d |\n", "offset_in_range",
                 ptpClock.isOffsetInRange());
         }
-        if (event2Sub & eventSyncedToGM) {
+        if (event2Sub & EventSyncedToGM) {
             printf("| %-25s | %-22d |\n", "synced_to_primary_clock", ptpClock.isSyncedWithGm());
         }
-        if (event2Sub & eventASCapable) {
+        if (event2Sub & EventASCapable) {
             printf("| %-25s | %-22d |\n", "as_capable", ptpClock.isAsCapable());
         }
-        if (event2Sub & eventGMChanged) {
+        if (event2Sub & EventGMChanged) {
             printf("| %-25s | %-22d |\n", "gm_Changed", ptpClock.isGmChanged());
         }
         printf("|---------------------------|------------------------|\n");
@@ -308,13 +308,13 @@ int main(int argc, char *argv[])
             printf("| %-25s | %-22d |\n", "composite_event",
                 ptpClock.isCompositeEventMet());
         }
-        if (composite_event & eventGMOffset) {
+        if (composite_event & EventGMOffset) {
             printf("| - %-23s | %-22s |\n", "offset_in_range", " ");
         }
-        if (composite_event & eventSyncedToGM) {
+        if (composite_event & EventSyncedToGM) {
             printf("| - %-19s | %-22s |\n", "synced_to_primary_clock", " ");
         }
-        if (composite_event & eventASCapable) {
+        if (composite_event & EventASCapable) {
             printf("| - %-23s | %-22s |\n", "as_capable", " ");
         }
         if (composite_event) {
@@ -370,20 +370,20 @@ int main(int argc, char *argv[])
             if (event2Sub) {
             printf("|---------------------------|--------------|-------------|\n");
             }
-            if (event2Sub & eventGMOffset) {
+            if (event2Sub & EventGMOffset) {
                 printf("| %-25s | %-12d | %-11d |\n", "offset_in_range",
                     ptpClock.isOffsetInRange(),
                     ptpClock.getOffsetInRangeEventCount());
             }
-            if (event2Sub & eventSyncedToGM) {
+            if (event2Sub & EventSyncedToGM) {
                 printf("| %-25s | %-12d | %-11d |\n", "synced_to_primary_clock",
                     ptpClock.isSyncedWithGm(), ptpClock.getSyncedWithGmEventCount());
             }
-            if (event2Sub & eventASCapable) {
+            if (event2Sub & EventASCapable) {
                 printf("| %-25s | %-12d | %-11d |\n", "as_capable",
                     ptpClock.isAsCapable(), ptpClock.getAsCapableEventCount());
             }
-            if (event2Sub & eventGMChanged) {
+            if (event2Sub & EventGMChanged) {
                 printf("| %-25s | %-12d | %-11d |\n", "gm_Changed",
                     ptpClock.isGmChanged(), ptpClock.getGmChangedEventCount());
             }
@@ -410,13 +410,13 @@ int main(int argc, char *argv[])
                 printf("| %-25s | %-12d | %-11d |\n", "composite_event",
                     ptpClock.isCompositeEventMet(), ptpClock.getCompositeEventCount());
             }
-            if (composite_event & eventGMOffset) {
+            if (composite_event & EventGMOffset) {
                 printf("| - %-23s | %-12s | %-11s |\n", "offset_in_range", "", "");
             }
-            if (composite_event & eventSyncedToGM) {
+            if (composite_event & EventSyncedToGM) {
                 printf("| - %-19s | %-12s | %-11s |\n", "synced_to_primary_clock", "", "");
             }
-            if (composite_event & eventASCapable) {
+            if (composite_event & EventASCapable) {
                 printf("| - %-23s | %-12s | %-11s |\n", "as_capable", "", "");
             }
             if (composite_event) {

--- a/clkmgr/utest/clockmanager.cpp
+++ b/clkmgr/utest/clockmanager.cpp
@@ -152,18 +152,18 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
     // Get the current state of the timebase
     PTPClockEvent ptp4lEventState = state.get_ptp4lEventState();
     SysClockEvent chronyEventState = state.get_chronyEventState();
-    // Update eventGMOffset
+    // Update EventGMOffset
     ptpClockEventHandler.setClockOffset(ptp4lEventState, 23);
     ptpClockEventHandler.setOffsetInRange(ptp4lEventState, true);
     ptpClockEventHandler.setOffsetInRangeEventCount(ptp4lEventState, 8);
-    // Update eventSyncedToGM
+    // Update EventSyncedToGM
     ptpClockEventHandler.setSyncedWithGm(ptp4lEventState, true);
     ptpClockEventHandler.setSyncedWithGmEventCount(ptp4lEventState, 9);
-    // Update eventGMChanged
+    // Update EventGMChanged
     ptpClockEventHandler.setGmIdentity(ptp4lEventState, 0x1234ABCD);
     ptpClockEventHandler.setGmChanged(ptp4lEventState, true);
     ptpClockEventHandler.setGmChangedEventCount(ptp4lEventState, 10);
-    // Update eventASCapable
+    // Update EventASCapable
     ptpClockEventHandler.setAsCapable(ptp4lEventState, true);
     ptpClockEventHandler.setAsCapableEventCount(ptp4lEventState, 11);
     // Update composite event

--- a/clkmgr/utest/subscription.cpp
+++ b/clkmgr/utest/subscription.cpp
@@ -36,15 +36,15 @@ TEST(SubscriptionTest, setAndGet)
     const PTPClockSubscription &org = subscription.getPtpSubscription();
     PTPClockSubscription copy = org;
     EXPECT_EQ(org.getCompositeEventMask(), 0);
-    EXPECT_FALSE(copy.setEventMask(eventLast));
-    EXPECT_TRUE(copy.setEventMask(eventLast - 1));
+    EXPECT_FALSE(copy.setEventMask(EventLast));
+    EXPECT_TRUE(copy.setEventMask(EventLast - 1));
     EXPECT_FALSE(copy.setCompositeEventMask(COMPOSITE_EVENT_ALL + 1));
     EXPECT_TRUE(copy.setCompositeEventMask(COMPOSITE_EVENT_ALL));
     subscription.setPtpSubscription(copy);
-    EXPECT_EQ(subscription.getPtpSubscription().getEventMask(), eventLast - 1);
+    EXPECT_EQ(subscription.getPtpSubscription().getEventMask(), EventLast - 1);
     EXPECT_EQ(subscription.getPtpSubscription().getCompositeEventMask(),
         COMPOSITE_EVENT_ALL);
-    EXPECT_EQ(org.getEventMask(), eventLast - 1);
+    EXPECT_EQ(org.getEventMask(), EventLast - 1);
     EXPECT_EQ(org.getCompositeEventMask(), COMPOSITE_EVENT_ALL);
 }
 

--- a/wrappers/perl/clkmgr_test.pl
+++ b/wrappers/perl/clkmgr_test.pl
@@ -1,0 +1,363 @@
+#!/usr/bin/perl
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation.
+#
+# Test Perl Clock Manager client
+#
+# @author Christopher Hall <christopher.s.hall@@intel.com>
+# @copyright © 2024 Intel Corporation.
+#
+# @note This is a sample code, not a product! You should use it as a reference.
+#
+# To run in development environment:
+# LD_PRELOAD=../../.libs/libclkmgr.so PERL5LIB=. ./clkmgr_test.pl
+#
+###############################################################################
+
+use threads;
+use threads::shared;
+use POSIX;
+use Time::HiRes;
+use Getopt::Std;
+use ClkMgrLib;
+
+my $signal_flag :shared = 0;
+
+sub signal_handler()
+{
+    my($sig) = @_;
+    print " Exit ...\n";
+    $signal_flag = 1;
+}
+
+sub isPositiveValue
+{
+    my ($optarg, $errorMessage) = @_;
+    my $ret = int($optarg);
+    die $errorMessage unless $ret > 0;
+    $ret;
+}
+
+sub ClockManagerGetTime
+{
+    my $ts = ClkMgrLib::timespec->new;
+    if(ClkMgrLib::ClockManager::getTime($ts)) {
+        printf "[clkmgr] Current Time of CLOCK_REALTIME: %ld ns\n",
+                ($ts->swig_tv_sec_get * 1000000000) + $ts->swig_tv_nsec_get;
+    } else {
+        POSIX::perror("clock_gettime failed");
+    }
+}
+
+sub main
+{
+    my $ptp4lClockOffsetThreshold = 100000;
+    my $chronyClockOffsetThreshold = 100000;
+    my $subscribeAll = 0;
+    my $userInput = 0;
+    my $idleTime = 1;
+    my $timeout = 10;
+    my @index; # Array of indexes to subscribe
+
+    my $event2Sub = $ClkMgrLib::EventGMOffset | $ClkMgrLib::EventSyncedToGM |
+        $ClkMgrLib::EventASCapable | $ClkMgrLib::EventGMChanged;
+    my $composite_event = $ClkMgrLib::EventGMOffset |
+        $ClkMgrLib::EventSyncedToGM | $ClkMgrLib::EventASCapable;
+
+    my $clockSyncData = ClkMgrLib::ClockSyncData->new;
+    my $ptpClock = $clockSyncData->getPtp();
+    my $sysClock = $clockSyncData->getSysClock();
+
+    my $ptp4lSub = ClkMgrLib::PTPClockSubscription->new;
+    my $chronySub = ClkMgrLib::SysClockSubscription->new;
+
+    my @overallSub; # Array of ClkMgrLib::ClockSyncSubscription
+
+    my $ret = getopts('aps:c:u:l:i:t:n:m:h');
+    if($opt_h || !$ret) {
+        my $event2SubHex = sprintf '0x%x', $event2Sub;
+        my $composite_eventHex = sprintf '0x%x', $composite_event;
+        my $help = <<"END_MESSAGE";
+Usage of $0:
+Options:
+  -a subscribe to all time base indices
+     Default: timeBaseIndex: 1
+  -p enable user to subscribe to specific time base indices
+  -s subscribe_event_mask
+     Default: $event2SubHex
+     Bit 0: EventGMOffset
+     Bit 1: EventSyncedToGM
+     Bit 2: EventASCapable
+     Bit 3: EventGMChanged
+  -c composite_event_mask
+     Default: $composite_eventHex
+     Bit 0: EventGMOffset
+     Bit 1: EventSyncedToGM
+     Bit 2: EventASCapable
+  -l gm offset threshold (ns)
+     Default: $ptp4lClockOffsetThreshold ns
+  -i idle time (s)
+     Default: $idleTime s
+  -m chrony offset threshold (ns)
+     Default: $chronyClockOffsetThreshold ns
+  -t timeout in waiting notification event (s)
+     Default: $timeout s
+END_MESSAGE
+        $ret ? print($help) : die $help;
+        return;
+    }
+    $subscribeAll = $opt_a ? 1 : 0;
+    $userInput = $subscribeAll ? 0 : ($opt_p ? 1 : 0);
+    $event2Sub = POSIX::strtoul($opt_s, 0) if $opt_s;
+    $composite_event = POSIX::strtoul($opt_c, 0) if $opt_c;
+    $ptp4lClockOffsetThreshold =
+        isPositiveValue($opt_l, 'Invalid ptp4l GM Offset threshold!') if $opt_l;
+    $idleTime = isPositiveValue($opt_i, 'Invalid idle time!') if $opt_i;
+    $timeout = isPositiveValue($opt_t, 'Invalid timeout!') if $opt_t;
+    $chronyClockOffsetThreshold =
+        isPositiveValue($opt_m, 'Invalid Chrony Offset threshold!') if $opt_m;
+    $SIG{'INT'} = \&signal_handler;
+    $SIG{'TERM'} = \&signal_handler;
+    $SIG{'HUP'} = \&signal_handler;
+    $ptp4lSub->setEventMask($event2Sub);
+    $ptp4lSub->setClockOffsetThreshold($ptp4lClockOffsetThreshold);
+    $ptp4lSub->setCompositeEventMask($composite_event);
+    $chronySub->setClockOffsetThreshold($chronyClockOffsetThreshold);
+    printf "[clkmgr] set subscribe event : 0x%x\n", $ptp4lSub->getEventMask();
+    printf "[clkmgr] set composite event : 0x%x\n".
+        $ptp4lSub->getCompositeEventMask();
+    print "GM Offset threshold: $ptp4lClockOffsetThreshold ns\n";
+    print "Chrony Offset threshold: $chronyClockOffsetThreshold ns\n";
+
+    if($userInput) {
+        print 'Enter the time base indices to subscribe ' .
+              '(comma-separated, default is 1): ';
+        my $line = <STDIN>;
+        chomp $line;
+        unless($line =~ /^$/) {
+            my $idx = int($line);
+            die 'Invalid time base index: $line!' unless $idx > 0;
+            push(@index, $idx);
+        } else {
+            warn "Invalid input. Using default time base index 1.\n";
+        }
+    }
+
+    my $dieMsg;
+    unless(ClkMgrLib::ClockManager::connect()) {
+        $dieMsg = '[clkmgr] failure in connecting !!!';
+        goto do_exit
+    }
+    sleep 1;
+    print "[clkmgr] List of available clock:\n";
+    # Print out each member of the Time Base configuration
+    my $size = ClkMgrLib::TimeBaseConfigurations::size();
+    for(my $i = 1; $i <= $size; $i++) {
+        my $cfg = ClkMgrLib::TimeBaseConfigurations::getRecord($i);
+        my $idx = $cfg->index();
+        print "TimeBaseIndex: $idx\n";
+        print 'timeBaseName: ' . $cfg->name() . "\n";
+        my $Subscribe = ClkMgrLib::ClockSyncSubscription->new;
+        if($cfg->havePtp()) {
+            my $ptp = $cfg->ptp();
+            print 'interfaceName: ' . $ptp->ifName() . "\n";
+            print 'transportSpecific: ' . $ptp->transportSpecific() . "\n";
+            print 'domainNumber: ' . $ptp->domainNumber() . "\n";
+            $Subscribe->setPtpSubscription($ptp4lSub);
+        }
+        $Subscribe->setSysSubscription($chronySub) if $cfg->haveSysClock();
+        $overallSub[$idx] = $Subscribe;
+        print "\n";
+        push(@index, $idx) if $subscribeAll;
+    }
+
+    # Default
+    push(@index, 1) if 0 == scalar @index;
+
+    my $hd2 = '|'.('-'x 27).'|'.('-'x 24).'|';
+    for(@index) {
+        my $idx = $_;
+        print "Subscribe to time base index: $idx\n";
+        unless(ClkMgrLib::ClockManager::subscribe($overallSub[$idx],
+            $idx, $clockSyncData)) {
+            $dieMsg = '[clkmgr] Failure in subscribing to clkmgr Proxy !!!';
+            goto do_exit;
+        }
+        printf "[clkmgr][%.3f] Obtained data from Subscription Event:\n",
+            Time::HiRes::time;
+        ClockManagerGetTime;
+        printf "$hd2\n" .
+               "| %-25s | %-22s |\n", 'Event', 'Event Status';
+        if ($event2Sub != 0) {
+            print "$hd2\n";
+            printf "| %-25s | %-22d |\n",
+                'offset_in_range', $ptpClock->isOffsetInRange()
+                if $event2Sub & $ClkMgrLib::EventGMOffset;
+            printf "| %-25s | %-22d |\n", 'synced_to_primary_clock',
+                $ptpClock->isSyncedWithGm()
+                if $event2Sub & $ClkMgrLib::EventSyncedToGM;
+            printf "| %-25s | %-22d |\n", 'as_capable', $ptpClock->isAsCapable()
+                if $event2Sub & $ClkMgrLib::EventASCapable;
+            printf "| %-25s | %-22d |\n", 'gm_Changed', $ptpClock->isGmChanged()
+                if $event2Sub & $ClkMgrLib::EventGMChanged;
+        }
+        print "$hd2\n";
+        my $gmClockUUID = $ptpClock->getGmIdentity();
+        my @gm_identity;
+        # Copy the uint64_t into the array
+        for (my $i = 0; $i < 8; $i++) {
+            $gm_identity[$i] = ($gmClockUUID >> (8 * (7 - $i))) & 0xff;
+        }
+        printf "| %-25s | %02x%02x%02x.%02x%02x.%02x%02x%02x     |\n",
+            'GM UUID',
+            $gm_identity[0], $gm_identity[1],
+            $gm_identity[2], $gm_identity[3],
+            $gm_identity[4], $gm_identity[5],
+            $gm_identity[6], $gm_identity[7];
+        printf "| %-25s | %-19ld ns |\n" .
+               "| %-25s | %-19ld ns |\n" .
+               "| %-25s | %-19ld us |\n" .
+               "$hd2\n"
+               , 'clock_offset', $ptpClock->getClockOffset()
+               , 'notification_timestamp', $ptpClock->getNotificationTimestamp()
+               , 'gm_sync_interval', $ptpClock->getSyncInterval();
+        if ($composite_event != 0) {
+            printf "| %-25s | %-22d |\n", 'composite_event',
+                $ptpClock->isCompositeEventMet();
+            printf "| - %-23s | %-22s |\n", 'offset_in_range', ''
+                if $composite_event & $ClkMgrLib::EventGMOffset;
+            printf "| - %-19s | %-22s |\n", 'synced_to_primary_clock', ''
+                if $composite_event & $ClkMgrLib::EventSyncedToGM;
+            printf "| - %-23s | %-22s |\n", 'as_capable', ''
+                if $composite_event & $ClkMgrLib::EventASCapable;
+            print "$hd2\n\n";
+        } else {
+            print "\n";
+        }
+        printf "$hd2\n" .
+               "| %-25s | %-22d |\n" .
+               "$hd2\n" .
+               "| %-25s | %-19ld ns |\n" .
+               "| %-25s | %-19lx    |\n" .
+               "| %-25s | %-19ld us |\n" .
+               "$hd2\n\n"
+               , 'chrony_offset_in_range', $sysClock->isOffsetInRange()
+               , 'chrony_clock_offset', $sysClock->getClockOffset()
+               , 'chrony_clock_reference_id', $sysClock->getGmIdentity()
+               , 'chrony_polling_interval', $sysClock->getSyncInterval();
+    }
+    sleep 1;
+
+    my $hd2l = '|'.('-'x 27).'|'.('-'x 28).'|';
+    my $hd3b = '| %-25s | %-12d | %-11d |';
+    my $hd3 = '|'.('-'x 27).'|'.('-'x 14).'|'.('-'x 13).'|';
+
+    while (!$signal_flag) {
+        loop_idx: for(@index) {
+            goto do_exit if $signal_flag;
+            my $idx = $_;
+            printf "[clkmgr][%.3f] Waiting Notification " .
+                   "from time base index $idx ...\n",
+                Time::HiRes::time;
+
+            my $retval =
+                ClkMgrLib::ClockManager::statusWait($timeout, $idx, $clockSyncData);
+
+            if(!$retval) {
+                printf "[clkmgr][%.3f] No event status changes identified in " .
+                    "$timeout seconds.\n\n", Time::HiRes::time;
+                printf "[clkmgr][%.3f] sleep for $idleTime seconds...\n\n",
+                    Time::HiRes::time;
+                goto do_exit if $signal_flag;
+                sleep $idleTime;
+                next loop_idx;
+            } elsif ($retval < 0) {
+                printf "[clkmgr][%.3f] Terminating: lost " .
+                    "connection to clkmgr Proxy\n", Time::HiRes::time;
+                goto do_exit;
+            }
+
+            printf "[clkmgr][%.3f] Obtained data from Notification Event:\n",
+                Time::HiRes::time;
+            ClockManagerGetTime;
+            printf "$hd3\n" .
+                "| %-25s | %-12s | %-11s |\n",
+                'Event', 'Event Status', 'Event Count';
+            if ($event2Sub != 0) {
+                print "$hd3\n";
+                printf "$hd3b\n", 'offset_in_range',
+                    $ptpClock->isOffsetInRange(),
+                    $ptpClock->getOffsetInRangeEventCount()
+                    if $event2Sub & $ClkMgrLib::EventGMOffset;
+                printf "$hd3b\n", 'synced_to_primary_clock',
+                    $ptpClock->isSyncedWithGm(),
+                    $ptpClock->getSyncedWithGmEventCount()
+                    if $event2Sub & $ClkMgrLib::EventSyncedToGM;
+                printf "$hd3b\n", 'as_capable',
+                    $ptpClock->isAsCapable(), $ptpClock->getAsCapableEventCount()
+                    if $event2Sub & $ClkMgrLib::EventASCapable;
+                printf "$hd3b\n", 'gm_Changed',
+                    $ptpClock->isGmChanged(), $ptpClock->getGmChangedEventCount()
+                    if $event2Sub & $ClkMgrLib::EventGMChanged;
+            }
+            print "$hd3\n";
+
+            my $gmClockUUID = $ptpClock->getGmIdentity();
+            my @gm_identity;
+            # Copy the uint64_t into the array
+            for (my $i = 0; $i < 8; $i++) {
+                $gm_identity[$i] = ($gmClockUUID >> (8 * (7 - $i))) & 0xff;
+            }
+            printf "| %-25s |     %02x%02x%02x.%02x%02x.%02x%02x%02x     |\n",
+                'GM UUID',
+                $gm_identity[0], $gm_identity[1],
+                $gm_identity[2], $gm_identity[3],
+                $gm_identity[4], $gm_identity[5],
+                $gm_identity[6], $gm_identity[7];
+            printf "| %-25s |     %-19ld ns |\n" .
+                   "| %-25s |     %-19ld ns |\n" .
+                   "| %-25s |     %-19ld us |\n" .
+                   "$hd3\n"
+                   , 'clock_offset', $ptpClock->getClockOffset()
+                   , 'notification_timestamp', $ptpClock->getNotificationTimestamp()
+                   , 'gm_sync_interval', $ptpClock->getSyncInterval();
+            if ($composite_event != 0) {
+                printf "$hd3b\n", 'composite_event',
+                    $ptpClock->isCompositeEventMet(),
+                    $ptpClock->getCompositeEventCount();
+                printf "| - %-23s | %-12s | %-11s |\n", 'offset_in_range', '', ''
+                    if $composite_event & $ClkMgrLib::EventGMOffset;
+                printf "| - %-19s | %-12s | %-11s |\n",
+                    'synced_to_primary_clock', '', ''
+                    if $composite_event & $ClkMgrLib::EventSyncedToGM;
+                printf "| - %-23s | %-12s | %-11s |\n", 'as_capable', '', ''
+                    if $composite_event & $ClkMgrLib::EventASCapable;
+                print "$hd3\n\n";
+            } else {
+                print "\n";
+            }
+            printf "$hd2l\n" .
+                   "$hd3b\n" .
+                   "$hd2l\n" .
+                   "| %-25s |     %-19ld ns |\n" .
+                   "| %-25s |     %-19lx    |\n" .
+                   "| %-25s |     %-19ld us |\n" .
+                   "$hd2l\n\n"
+                   , 'chrony_offset_in_range', $sysClock->isOffsetInRange(),
+                     $sysClock->getOffsetInRangeEventCount()
+                   , 'chrony_clock_offset', $sysClock->getClockOffset()
+                   , 'chrony_clock_reference_id', $sysClock->getGmIdentity()
+                   , 'chrony_polling_interval', $sysClock->getSyncInterval();
+            printf "[clkmgr][%.3f] sleep for %d seconds...\n\n",
+                Time::HiRes::time, idleTime;
+            goto do_exit if $signal_flag;
+            sleep $idleTime;
+        }
+    }
+
+do_exit:
+
+    ClkMgrLib::ClockManager::disconnect();
+    die $dieMsg if $dieMsg;
+}
+main;

--- a/wrappers/python/clkmgr_test.py
+++ b/wrappers/python/clkmgr_test.py
@@ -1,0 +1,326 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation.
+#
+# Test Python Clock Manager client
+#
+# @author Christopher Hall <christopher.s.hall@@intel.com>
+# @copyright © 2024 Intel Corporation.
+#
+# @note This is a sample code, not a product! You should use it as a reference.
+#
+# To run in development environment:
+# LD_PRELOAD=../../.libs/libclkmgr.so PYTHONPATH=3 python3 clkmgr_test.py
+#
+###############################################################################
+
+import os
+import errno
+import sys
+import getopt
+import signal
+import time
+import clkmgr
+
+# Use to capture signal break
+signal_flag = False
+# Parameters that can be set with command line
+ptp4lClockOffsetThreshold = 100000
+chronyClockOffsetThreshold = 100000
+subscribeAll = False
+userInput = False
+idleTime = 1
+timeout = 10
+event2Sub = (clkmgr.EventGMOffset | clkmgr.EventSyncedToGM |
+    clkmgr.EventASCapable | clkmgr.EventGMChanged)
+composite_event = (clkmgr.EventGMOffset | clkmgr.EventSyncedToGM |
+    clkmgr.EventASCapable)
+# Subscribe data
+ptp4lSub = clkmgr.PTPClockSubscription()
+chronySub = clkmgr.SysClockSubscription()
+# Array of indexes to subscribe
+index = list()
+
+def signal_handler(signum, frame):
+    global signal_flag
+    print(' Exit ...')
+    signal_flag = True
+
+def isPositiveValue(optarg, errorMessage):
+    ret = int(optarg)
+    if ret <= 0:
+        print(errorMessage)
+        sys.exit(2)
+    return ret
+
+def ClockManagerGetTime():
+    ts = clkmgr.timespec()
+    if clkmgr.ClockManager.getTime(ts):
+        print("[clkmgr] Current Time of CLOCK_REALTIME: {} ns"
+            .format((ts.tv_sec * 1000000000) + ts.tv_nsec))
+    else:
+        print("clock_gettime failed: {}".format(os.strerror(errno.errorcode)))
+
+def usage():
+    print('''
+Usage of {}:
+Options:
+  -a subscribe to all time base indices
+     Default: timeBaseIndex: 1
+  -p enable user to subscribe to specific time base indices
+  -s subscribe_event_mask
+     Default: {}
+     Bit 0: EventGMOffset
+     Bit 1: EventSyncedToGM
+     Bit 2: EventASCapable
+     Bit 3: EventGMChanged
+  -c composite_event_mask
+     Default: {}
+     Bit 0: EventGMOffset
+     Bit 1: EventSyncedToGM
+     Bit 2: EventASCapable
+  -l gm offset threshold (ns)
+     Default: {} ns
+  -i idle time (s)
+     Default: {} s
+  -m chrony offset threshold (ns)
+     Default: {} ns
+  -t timeout in waiting notification event (s)
+     Default: {} s
+'''[:-1].format(sys.argv[0], hex(event2Sub),
+    hex(composite_event), ptp4lClockOffsetThreshold,
+    idleTime, chronyClockOffsetThreshold, timeout))
+
+def main():
+    global subscribeAll, userInput, event2Sub, composite_event, \
+        ptp4lClockOffsetThreshold, idleTime, timeout, \
+        chronyClockOffsetThreshold
+    try:
+        opts, args = getopt.gnu_getopt(sys.argv[1:], 'aps:c:u:l:i:t:n:m:h')
+    except getopt.GetoptError as err:
+        print(err)
+        usage()
+        sys.exit(2)
+    for o, a in opts:
+        if o == '-h':
+            usage()
+            return
+        elif o == '-a':
+            subscribeAll = True
+        elif o == '-p':
+            userInput = True
+        elif o == '-s':
+            event2Sub = int(a, base=0)
+        elif o == '-c':
+            composite_event = int(a, base=0)
+        elif o == '-l':
+            ptp4lClockOffsetThreshold = isPositiveValue(a,
+                'Invalid ptp4l GM Offset threshold!')
+        elif o == '-i':
+            idleTime = isPositiveValue(a, 'Invalid idle time!')
+        elif o == '-t':
+            timeout = isPositiveValue(a, 'Invalid timeout!')
+        elif o == '-m':
+            chronyClockOffsetThreshold = isPositiveValue(a,
+                'Invalid Chrony Offset threshold!')
+        else:
+            assert False, 'unhandled option'
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGHUP, signal_handler)
+    ptp4lSub.setEventMask(event2Sub)
+    ptp4lSub.setClockOffsetThreshold(ptp4lClockOffsetThreshold)
+    ptp4lSub.setCompositeEventMask(composite_event)
+    chronySub.setClockOffsetThreshold(chronyClockOffsetThreshold)
+    print('[clkmgr] set subscribe event : {}'
+        .format(hex(ptp4lSub.getEventMask())))
+    print('[clkmgr] set composite event : {}'
+        .format(hex(ptp4lSub.getCompositeEventMask())))
+    print('GM Offset threshold: {} ns'.format(ptp4lClockOffsetThreshold))
+    print('Chrony Offset threshold: {} ns'.format(chronyClockOffsetThreshold))
+    if userInput and not subscribeAll:
+        line = input('Enter the time base indices to subscribe (comma-separated, default is 1): ')
+        if len(line) > 0:
+            try:
+                idx = int(line)
+            except:
+                idx = 0
+            if idx <= 0:
+                print('Invalid time base index: line!')
+                sys.exit(2)
+            index.append(idx)
+        else:
+            print('Invalid input. Using default time base index 1.')
+    ret = main_body()
+    clkmgr.ClockManager.disconnect()
+    if ret != None and ret > 0:
+        sys.exit(2)
+
+def main_body():
+    clockSyncData = clkmgr.ClockSyncData()
+    ptpClock = clockSyncData.getPtp()
+    sysClock = clockSyncData.getSysClock()
+    if not clkmgr.ClockManager.connect():
+        print('[clkmgr] failure in connecting !!!')
+        return 2
+    time.sleep(1)
+    print('[clkmgr] List of available clock:')
+    # Print out each member of the Time Base configuration
+    size = clkmgr.TimeBaseConfigurations.size()
+    overallSub = [None] * (size + 1) # Array of clkmgr.ClockSyncSubscription
+    for i in range(size):
+        cfg = clkmgr.TimeBaseConfigurations.getRecord(i + 1)
+        idx = cfg.index()
+        print('TimeBaseIndex: {}'.format(idx))
+        print('timeBaseName: {}'.format(cfg.name()))
+        Subscribe = clkmgr.ClockSyncSubscription()
+        if cfg.havePtp():
+            ptp = cfg.ptp()
+            print('interfaceName: {}'.format(ptp.ifName()))
+            print('transportSpecific: {}'.format(ptp.transportSpecific()))
+            print('domainNumber: {}'.format(ptp.domainNumber()))
+            Subscribe.setPtpSubscription(ptp4lSub)
+        if cfg.haveSysClock():
+            Subscribe.setSysSubscription(chronySub)
+        overallSub[idx] = Subscribe
+        if subscribeAll:
+            index.append(idx)
+    # Default
+    if len(index) == 0:
+        index.append(1)
+
+    gm_identity = [None] * 8
+    hd2 = '|'+('-'*27)+'|'+('-'*24)+'|'
+    for idx in index:
+        print('Subscribe to time base index: {}'.format(idx))
+        if not clkmgr.ClockManager.subscribe(overallSub[idx], idx, clockSyncData):
+            print('[clkmgr] Failure in subscribing to clkmgr Proxy !!!')
+            return 2
+        print('[clkmgr][%.3f] Obtained data from Subscription Event:' % time.time())
+        ClockManagerGetTime
+        print(hd2)
+        print('| %-25s | %-22s |' % ('Event', 'Event Status'))
+        if event2Sub != 0:
+            print(hd2)
+            if event2Sub & clkmgr.EventGMOffset:
+                print('| %-25s | %-22d |' % ('offset_in_range', ptpClock.isOffsetInRange()))
+            if event2Sub & clkmgr.EventSyncedToGM:
+                print('| %-25s | %-22d |' % ('synced_to_primary_clock', ptpClock.isSyncedWithGm()))
+
+            if event2Sub & clkmgr.EventASCapable:
+                print('| %-25s | %-22d |' % ('as_capable', ptpClock.isAsCapable()))
+            if event2Sub & clkmgr.EventGMChanged:
+                print('| %-25s | %-22d |' % ('gm_Changed', ptpClock.isGmChanged()))
+        print(hd2)
+        gmClockUUID = ptpClock.getGmIdentity()
+        # Copy the uint64_t into the array
+        for i in range(8):
+            gm_identity[i] = (gmClockUUID >> (8 * (7 - i))) & 0xff
+        print('| %-25s | %02x%02x%02x.%02x%02x.%02x%02x%02x     |' % ('GM UUID',
+            gm_identity[0], gm_identity[1],
+            gm_identity[2], gm_identity[3],
+            gm_identity[4], gm_identity[5],
+            gm_identity[6], gm_identity[7]))
+        print('| %-25s | %-19ld ns |' % ('clock_offset', ptpClock.getClockOffset()))
+        print('| %-25s | %-19ld ns |' % ('notification_timestamp', ptpClock.getNotificationTimestamp()))
+        print('| %-25s | %-19ld us |' % ('gm_sync_interval', ptpClock.getSyncInterval()))
+        print(hd2)
+        if composite_event != 0:
+            print('| %-25s | %-22d |' % ('composite_event', ptpClock.isCompositeEventMet()))
+
+            if composite_event & clkmgr.EventGMOffset:
+                print('| - %-23s | %-22s |' % ('offset_in_range', ''))
+            if composite_event & clkmgr.EventSyncedToGM:
+                print('| - %-19s | %-22s |' % ('synced_to_primary_clock', ''))
+            if composite_event & clkmgr.EventASCapable:
+                print('| - %-23s | %-22s |' % ('as_capable', ''))
+
+            print(hd2)
+        print()
+        print(hd2)
+        print('| %-25s | %-22d |' % ('chrony_offset_in_range', sysClock.isOffsetInRange()))
+        print(hd2)
+        print('| %-25s | %-19ld ns |' % ('chrony_clock_offset', sysClock.getClockOffset()))
+        print('| %-25s | %-19lx    |' % ('chrony_clock_reference_id', sysClock.getGmIdentity()))
+        print('| %-25s | %-19ld us |' % ('chrony_polling_interval', sysClock.getSyncInterval()))
+        print(hd2)
+        print()
+
+    time.sleep(1)
+
+    hd2l = '|'+('-'* 27)+'|'+('-'* 28)+'|'
+    hd3b = '| %-25s | %-12d | %-11d |'
+    hd3 = '|'+('-'* 27)+'|'+('-'* 14)+'|'+('-'* 13)+'|'
+
+    while not signal_flag:
+        for idx in index:
+            if signal_flag:
+                return
+            print('[clkmgr][%.3f] Waiting Notification from time base index %d ...' % (time.time(), idx))
+            retval = clkmgr.ClockManager.statusWait(timeout, idx, clockSyncData)
+            if retval == 0:
+                print('[clkmgr][%.3f] No event status changes identified in timeout seconds.' % time.time())
+                print()
+                print('[clkmgr][%.3f] sleep for %d seconds...' % (time.time(), idleTime))
+                print()
+                if signal_flag:
+                    return
+                time.sleep(idleTime)
+                continue
+            elif retval < 0:
+                print('[clkmgr][%.3f] Terminating: lost connection to clkmgr Proxy' % time.time())
+                return
+
+            print('[clkmgr][%.3f] Obtained data from Notification Event:' % time.time())
+            ClockManagerGetTime
+            print(hd3)
+            print('| %-25s | %-12s | %-11s |' % ('Event', 'Event Status', 'Event Count'))
+            if event2Sub != 0:
+                print(hd3)
+                if event2Sub & clkmgr.EventGMOffset:
+                    print(hd3b % ('offset_in_range', ptpClock.isOffsetInRange(), ptpClock.getOffsetInRangeEventCount()))
+                if event2Sub & clkmgr.EventSyncedToGM:
+                    print(hd3b % ('synced_to_primary_clock', ptpClock.isSyncedWithGm(), ptpClock.getSyncedWithGmEventCount()))
+                if event2Sub & clkmgr.EventASCapable:
+                    print(hd3b % ('as_capable', ptpClock.isAsCapable(), ptpClock.getAsCapableEventCount()))
+                if event2Sub & clkmgr.EventGMChanged:
+                    print(hd3b % ('gm_Changed', ptpClock.isGmChanged(), ptpClock.getGmChangedEventCount()))
+            print(hd3)
+            gmClockUUID = ptpClock.getGmIdentity()
+            # Copy the uint64_t into the array
+            for i in range(8):
+                gm_identity[i] = (gmClockUUID >> (8 * (7 - i))) & 0xff
+            print('| %-25s |     %02x%02x%02x.%02x%02x.%02x%02x%02x     |' % ('GM UUID',
+                gm_identity[0], gm_identity[1],
+                gm_identity[2], gm_identity[3],
+                gm_identity[4], gm_identity[5],
+                gm_identity[6], gm_identity[7]))
+            print('| %-25s |     %-19ld ns |' % ('clock_offset', ptpClock.getClockOffset()))
+            print('| %-25s |     %-19ld ns |' % ('notification_timestamp', ptpClock.getNotificationTimestamp()))
+            print('| %-25s |     %-19ld us |' % ('gm_sync_interval', ptpClock.getSyncInterval()))
+            print(hd3)
+            if composite_event != 0:
+                print(hd3b % ('composite_event', ptpClock.isCompositeEventMet(), ptpClock.getCompositeEventCount()))
+
+                if composite_event & clkmgr.EventGMOffset:
+                    print('| - %-23s | %-12s | %-11s |' % ('offset_in_range', '', ''))
+                if composite_event & clkmgr.EventSyncedToGM:
+                    print('| - %-19s | %-12s | %-11s |' % ('synced_to_primary_clock', '', ''))
+                if composite_event & clkmgr.EventASCapable:
+                    print('| - %-23s | %-12s | %-11s |' % ('as_capable', '', ''))
+                print(hd3)
+            print()
+            print(hd2l)
+            print(hd3b % ('chrony_offset_in_range', sysClock.isOffsetInRange(), sysClock.getOffsetInRangeEventCount()))
+            print(hd2l)
+            print('| %-25s |     %-19ld ns |' % ('chrony_clock_offset', sysClock.getClockOffset()))
+            print('| %-25s |     %-19lx    |' % ('chrony_clock_reference_id', sysClock.getGmIdentity()))
+            print('| %-25s |     %-19ld us |' % ('chrony_polling_interval', sysClock.getSyncInterval()))
+            print(hd2l)
+            print()
+            print('[clkmgr][%.3f] sleep for %d seconds...' % (time.time(), idleTime))
+            print()
+            if signal_flag:
+                return
+            time.sleep(idleTime)
+
+main()

--- a/wrappers/ruby/clkmgr_test.rb
+++ b/wrappers/ruby/clkmgr_test.rb
@@ -1,0 +1,328 @@
+#!/usr/bin/ruby
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation.
+#
+# Test Ruby Clock Manager client
+#
+# @author Christopher Hall <christopher.s.hall@@intel.com>
+# @copyright © 2024 Intel Corporation.
+#
+# @note This is a sample code, not a product! You should use it as a reference.
+#
+# To run in development environment
+# LD_PRELOAD=../../.libs/libclkmgr.so RUBYLIB=. ./clkmgr_test.rb
+#
+###############################################################################
+
+require 'getoptlong'
+require 'clkmgr'
+
+# Use to capture signal break
+$signal_flag = false
+# Parameters that can be set with command line
+$ptp4lClockOffsetThreshold = 100000
+$chronyClockOffsetThreshold = 100000
+$subscribeAll = false
+$idleTime = 1
+$timeout = 10
+$event2Sub = (Clkmgr::EventGMOffset | Clkmgr::EventSyncedToGM |
+    Clkmgr::EventASCapable | Clkmgr::EventGMChanged)
+$composite_event = (Clkmgr::EventGMOffset | Clkmgr::EventSyncedToGM |
+    Clkmgr::EventASCapable)
+# Subscribe data
+$ptp4lSub = Clkmgr::PTPClockSubscription.new
+$chronySub = Clkmgr::SysClockSubscription.new
+# Array of indexes to subscribe
+$index = Array.new
+
+def isPositiveValue(optarg, errorMessage)
+    ret = optarg.to_i
+    if ret <= 0 then
+        puts errorMessage
+        exit 2
+    end
+    return ret
+end
+
+def clockManagerGetTime
+    ts = Clkmgr::Timespec.new
+    if Clkmgr::ClockManager.getTime(ts) then
+        puts "[Clkmgr] Current Time of CLOCK_REALTIME: #{ (ts.tv_sec * 1000000000) + ts.tv_nsec } ns"
+    else
+        puts 'clock_gettime failed'
+    end
+end
+
+def usage
+    puts <<-EOF
+Usage of #{ $0 }
+Options
+  -a subscribe to all time base indices
+     Default: timeBaseIndex: 1
+  -p enable user to subscribe to specific time base indices
+  -s subscribe_event_mask
+     Default: 0x#{ $event2Sub.to_s(16) }
+     Bit 0: EventGMOffset
+     Bit 1: EventSyncedToGM
+     Bit 2: EventASCapable
+     Bit 3: EventGMChanged
+  -c composite_event_mask
+     Default: 0x#{ $composite_event.to_s(16) }
+     Bit 0: EventGMOffset
+     Bit 1: EventSyncedToGM
+     Bit 2: EventASCapable
+  -l gm offset threshold (ns)
+     Default: #{ $ptp4lClockOffsetThreshold } ns
+  -i idle time (s)
+     Default: #{ $idleTime } s
+  -m chrony offset threshold (ns)
+     Default: #{ $chronyClockOffsetThreshold } ns
+  -t $timeout in waiting notification event (s)
+     Default: #{ $timeout } s
+EOF
+end
+
+def main
+    userInput = false
+    opts = GetoptLong.new(
+      [ '--a', '-a', GetoptLong::NO_ARGUMENT ],
+      [ '--p', '-p', GetoptLong::NO_ARGUMENT ],
+      [ '--s', '-s', GetoptLong::REQUIRED_ARGUMENT ],
+      [ '--c', '-c', GetoptLong::REQUIRED_ARGUMENT ],
+      [ '--u', '-u', GetoptLong::REQUIRED_ARGUMENT ],
+      [ '--l', '-l', GetoptLong::REQUIRED_ARGUMENT ],
+      [ '--i', '-i', GetoptLong::REQUIRED_ARGUMENT ],
+      [ '--t', '-t', GetoptLong::REQUIRED_ARGUMENT ],
+      [ '--n', '-n', GetoptLong::REQUIRED_ARGUMENT ],
+      [ '--m', '-m', GetoptLong::REQUIRED_ARGUMENT ],
+      [ '--h', '-h', GetoptLong::NO_ARGUMENT ],
+    )
+    begin
+        opts.each do |opt, arg|
+          case opt
+            when '--h'
+                usage
+                return
+            when '--a'
+                $subscribeAll = true
+            when '--p'
+                userInput = true
+            when '--s'
+                $event2Sub = arg.to_i(0)
+            when '--c'
+                $composite_event = arg.to_i(0)
+            when '--l'
+                $ptp4lClockOffsetThreshold = isPositiveValue(arg, 'Invalid ptp4l GM Offset threshold!')
+            when '--i'
+                $idleTime = isPositiveValue(arg, 'Invalid idle time!')
+            when '--t'
+                $timeout = isPositiveValue(arg, 'Invalid $timeout!')
+            when '--m'
+                $chronyClockOffsetThreshold = isPositiveValue(arg, 'Invalid Chrony Offset threshold!')
+          end
+        end
+    rescue
+        usage
+        exit 2
+    end
+    Signal.trap('INT') do
+        puts ' Exit ...'
+        $signal_flag = true
+    end
+    Signal.trap('TERM') do
+        puts ' Exit ...'
+        $signal_flag = true
+    end
+    Signal.trap('HUP') do
+        puts ' Exit ...'
+        $signal_flag = true
+    end
+    $ptp4lSub.setEventMask($event2Sub)
+    $ptp4lSub.setClockOffsetThreshold($ptp4lClockOffsetThreshold)
+    $ptp4lSub.setCompositeEventMask($composite_event)
+    $chronySub.setClockOffsetThreshold($chronyClockOffsetThreshold)
+    puts '[Clkmgr] set subscribe event : 0x' + $ptp4lSub.getEventMask().to_s(16)
+    puts '[Clkmgr] set composite event : 0x' + $ptp4lSub.getCompositeEventMask().to_s(16)
+    puts "GM Offset threshold: #{ $ptp4lClockOffsetThreshold } ns"
+    puts "Chrony Offset threshold:  #{ $chronyClockOffsetThreshold } ns"
+    if userInput and !$subscribeAll then
+        puts 'test input'
+        print 'Enter the time base indices to subscribe (comma-separated, default is 1): '
+        line = gets.chomp
+        if line.length > 0 then
+            idx = line.to_i
+            if idx <= 0 then
+                puts 'Invalid time base index: ' + line
+                exit 2
+            end
+            $index.push(idx)
+        else
+            puts 'Invalid input. Using default time base index 1.'
+        end
+    end
+    ret = main_body()
+    Clkmgr::ClockManager.disconnect()
+    exit 2 if ret > 0
+end
+
+def main_body
+    clockSyncData = Clkmgr::ClockSyncData.new
+    ptpClock = clockSyncData.getPtp()
+    sysClock = clockSyncData.getSysClock()
+    if !Clkmgr::ClockManager.connect() then
+        puts '[Clkmgr] failure in connecting !!!'
+        return 2
+    end
+    sleep 1
+    puts '[Clkmgr] List of available clock:'
+    # Print out each member of the Time Base configuration
+    size = Clkmgr::TimeBaseConfigurations.size()
+    overallSub = Array.new # Array of Clkmgr::ClockSyncSubscription
+    (1..size).each do |i|
+        cfg = Clkmgr::TimeBaseConfigurations.getRecord(i)
+        idx = cfg.index()
+        puts "TimeBaseIndex: #{ idx }"
+        puts 'timeBaseName: ' + cfg.name()
+        subscribe = Clkmgr::ClockSyncSubscription.new
+        if cfg.havePtp() then
+            ptp = cfg.ptp()
+            puts 'interfaceName: ' + ptp.ifName()
+            puts "transportSpecific: #{ ptp.transportSpecific() }"
+            puts "domainNumber: #{ ptp.domainNumber() }"
+            subscribe.setPtpSubscription($ptp4lSub)
+        end
+        subscribe.setSysSubscription($chronySub) if cfg.haveSysClock()
+        overallSub[idx] = subscribe
+        $index.push(idx) if $subscribeAll
+    end
+    # Default
+    $index.push(1) if $index.length == 0
+    gm_identity = Array.new(8)
+    hd2 = '|'+('-'*27)+'|'+('-'*24)+'|'
+    hd2b = '| %-25s | %-22s |'
+    $index.each do |idx|
+        puts "Subscribe to time base index: #{ idx }"
+        if !Clkmgr::ClockManager.subscribe(overallSub[idx], idx, clockSyncData) then
+            puts '[Clkmgr] Failure in subscribing to Clkmgr Proxy !!!'
+            return 2
+        end
+        puts '[Clkmgr][%.3f] Obtained data from Subscription Event:' % Time.now.to_f
+        clockManagerGetTime
+        puts hd2
+        puts hd2b % ['Event', 'Event Status']
+        if $event2Sub != 0 then
+            puts hd2
+            puts hd2b % ['offset_in_range', ptpClock.isOffsetInRange().to_s] if $event2Sub & Clkmgr::EventGMOffset
+            puts hd2b % ['synced_to_primary_clock', ptpClock.isSyncedWithGm().to_s] if $event2Sub & Clkmgr::EventSyncedToGM
+            puts hd2b % ['as_capable', ptpClock.isAsCapable().to_s] if $event2Sub & Clkmgr::EventASCapable
+            puts hd2b % ['gm_Changed', ptpClock.isGmChanged().to_s] if $event2Sub & Clkmgr::EventGMChanged
+        end
+        puts hd2
+        gmClockUUID = ptpClock.getGmIdentity()
+        # Copy the uint64_t into the array
+        (0..7).each do |i|
+            gm_identity[i] = (gmClockUUID >> (8 * (7 - i))) & 0xff
+        end
+        puts '| %-25s | %02x%02x%02x.%02x%02x.%02x%02x%02x     |' % ['GM UUID',
+            gm_identity[0], gm_identity[1],
+            gm_identity[2], gm_identity[3],
+            gm_identity[4], gm_identity[5],
+            gm_identity[6], gm_identity[7]]
+        puts '| %-25s | %-19d ns |' % ['clock_offset', ptpClock.getClockOffset()]
+        puts '| %-25s | %-19d ns |' % ['notification_timestamp', ptpClock.getNotificationTimestamp()]
+        puts '| %-25s | %-19d us |' % ['gm_sync_interval', ptpClock.getSyncInterval()]
+        puts hd2
+        if $composite_event != 0 then
+            puts '| %-25s | %-22s |' % ['$composite_event', ptpClock.isCompositeEventMet().to_s]
+            puts '| - %-23s | %-22s |' % ['offset_in_range', ''] if $composite_event & Clkmgr::EventGMOffset
+            puts '| - %-19s | %-22s |' % ['synced_to_primary_clock', ''] if $composite_event & Clkmgr::EventSyncedToGM
+            puts '| - %-23s | %-22s |' % ['as_capable', ''] if $composite_event & Clkmgr::EventASCapable
+            puts hd2
+        end
+        puts
+        puts hd2
+        puts '| %-25s | %-22s |' % ['chrony_offset_in_range', sysClock.isOffsetInRange().to_s]
+        puts hd2
+        puts '| %-25s | %-19d ns |' % ['chrony_clock_offset', sysClock.getClockOffset()]
+        puts '| %-25s | %-19x    |' % ['chrony_clock_reference_id', sysClock.getGmIdentity()]
+        puts '| %-25s | %-19d us |' % ['chrony_polling_interval', sysClock.getSyncInterval()]
+        puts hd2
+        puts
+    end
+
+    sleep 1
+
+    hd2l = '|'+('-'* 27)+'|'+('-'* 28)+'|'
+    hd3b = '| %-25s | %-12s | %-11d |'
+    hd3 = '|'+('-'* 27)+'|'+('-'* 14)+'|'+('-'* 13)+'|'
+
+    while !$signal_flag
+        $index.each do |idx|
+            return 0 if $signal_flag
+            puts '[Clkmgr][%.3f] Waiting Notification from time base index idx ...' % Time.now.to_f
+            retval = Clkmgr::ClockManager.statusWait($timeout, idx, clockSyncData)
+            if retval == 0 then
+                puts '[Clkmgr][%.3f] No event status changes identified in $timeout seconds.' % Time.now.to_f
+                puts
+                puts '[Clkmgr][%.3f] sleep for %d seconds...' % [Time.now.to_f, $idleTime]
+                puts
+                return 0 if $signal_flag
+                sleep $idleTime
+                next
+            elsif retval < 0 then
+                puts '[Clkmgr][%.3f] Terminating: lost connection to Clkmgr Proxy' % Time.now.to_f
+                return 0
+            end
+
+            puts '[Clkmgr][%.3f] Obtained data from Notification Event:' % Time.now.to_f
+            clockManagerGetTime
+            puts hd3
+            puts '| %-25s | %-12s | %-11s |' % ['Event', 'Event Status', 'Event Count']
+            if $event2Sub != 0 then
+                puts hd3
+                puts hd3b % ['offset_in_range', ptpClock.isOffsetInRange().to_s, ptpClock.getOffsetInRangeEventCount()] if $event2Sub & Clkmgr::EventGMOffset
+                puts hd3b % ['synced_to_primary_clock', ptpClock.isSyncedWithGm().to_s, ptpClock.getSyncedWithGmEventCount()] if $event2Sub & Clkmgr::EventSyncedToGM
+                puts hd3b % ['as_capable', ptpClock.isAsCapable().to_s, ptpClock.getAsCapableEventCount()] if $event2Sub & Clkmgr::EventASCapable
+                puts hd3b % ['gm_Changed', ptpClock.isGmChanged().to_s, ptpClock.getGmChangedEventCount()] if $event2Sub & Clkmgr::EventGMChanged
+            end
+            puts hd3
+            gmClockUUID = ptpClock.getGmIdentity()
+            # Copy the uint64_t into the array
+            (0..7).each do |i|
+                gm_identity[i] = (gmClockUUID >> (8 * (7 - i))) & 0xff
+            end
+            puts '| %-25s |     %02x%02x%02x.%02x%02x.%02x%02x%02x     |' % ['GM UUID',
+                gm_identity[0], gm_identity[1],
+                gm_identity[2], gm_identity[3],
+                gm_identity[4], gm_identity[5],
+                gm_identity[6], gm_identity[7]]
+            puts '| %-25s |     %-19d ns |' % ['clock_offset', ptpClock.getClockOffset()]
+            puts '| %-25s |     %-19d ns |' % ['notification_timestamp', ptpClock.getNotificationTimestamp()]
+            puts '| %-25s |     %-19d us |' % ['gm_sync_interval', ptpClock.getSyncInterval()]
+            puts hd3
+            if $composite_event != 0 then
+                puts hd3b % ['$composite_event', ptpClock.isCompositeEventMet(), ptpClock.getCompositeEventCount()]
+                puts '| - %-23s | %-12s | %-11s |' % ['offset_in_range', '', ''] if $composite_event & Clkmgr::EventGMOffset
+                puts '| - %-19s | %-12s | %-11s |' % ['synced_to_primary_clock', '', ''] if $composite_event & Clkmgr::EventSyncedToGM
+                puts '| - %-23s | %-12s | %-11s |' % ['as_capable', '', ''] if $composite_event & Clkmgr::EventASCapable
+                puts hd3
+            end
+            puts
+            puts hd2l
+            puts hd3b % ['chrony_offset_in_range', sysClock.isOffsetInRange(), sysClock.getOffsetInRangeEventCount()]
+            puts hd2l
+            puts '| %-25s |     %-19d ns |' % ['chrony_clock_offset', sysClock.getClockOffset()]
+            puts '| %-25s |     %-19x    |' % ['chrony_clock_reference_id', sysClock.getGmIdentity()]
+            puts '| %-25s |     %-19d us |' % ['chrony_polling_interval', sysClock.getSyncInterval()]
+            puts hd2l
+            puts
+            puts '[Clkmgr][%.3f] sleep for %d seconds...' % [Time.now.to_f, $idleTime]
+            puts
+            return 0 if $signal_flag
+            sleep $idleTime
+        end
+    end
+    return 0
+end
+
+main

--- a/wrappers/ruby/warn.i
+++ b/wrappers/ruby/warn.i
@@ -14,10 +14,7 @@
 %warnfilter(SWIGWARN_RUBY_WRONG_NAME) implementSpecific_e;
 
 /* clkmgr warnings */
-%warnfilter(SWIGWARN_RUBY_WRONG_NAME) clkmgr_event_state;
-%warnfilter(SWIGWARN_RUBY_WRONG_NAME) clkmgr_event_count;
-%warnfilter(SWIGWARN_RUBY_WRONG_NAME) EventIndex;
-%warnfilter(SWIGWARN_RUBY_WRONG_NAME) ThresholdIndex;
+%warnfilter(SWIGWARN_RUBY_WRONG_NAME) timespec;
 
 /* See more warnings in libptpmgmt.i for SWIG_OPERS_xxxx */
 #define SWIG_OPERS_OPERATOR_PLUSEQ


### PR DESCRIPTION
<h1>Suggested PR Title - Enhance event handling, message queue access, and add comprehensive test scripts</h1>
Tested functionality:
![image](https://github.com/user-attachments/assets/5e251998-9e39-448d-8440-d82023a83cf1)

<h1 style='color: red;'>${\color{red}DO \space NOT \space EDIT \space ANYTHING}$</h1>

### Smart DevOps AI Agent for GitHub: Release Version: v1.2-ww18-2025


>### Start of generated PR Summary by Smart DevOps Agent for GitHub

## Types of major changes in the pull request
code_enhancement, feature_enhancement


___

## Pull request change summary
- Updated various files to use new event naming conventions and improved logic for event handling.
- Enhanced message queue handling by allowing all user access and increasing buffer sizes.
- Added new command-line options to control message queue access.
- Added comprehensive test scripts in Perl and Python for the Clock Manager client.


___

## High level Pull Request Summary
<table><thead><tr><th>Filename&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Summary of changes&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Link to file&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody>
<tr>
  <td><strong>clkmgr/client/clockmanager.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Changed the return type of a function from false to 0 to <br>correct the return type.
 <br><br> Type of change: <br>Code_Defects</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-2f93f3abd0c220a988e8802733bbe861ccc4ccfba1c46130ce1b7ed68c950382"> +1/-1</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/client/clockmanager_c.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Simplified the condition checks and directly set <br>subscriptions without separate enable calls.
 <br><br> Type <br>of change: Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-e018f4d845fa1379731ded3811b94b54e8b40febad5eca6b4e75ca5227ccb6ad"> +2/-6</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/client/subscription.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Fixed the event mask comparison to use EventLast and <br>automatically enable subscriptions when setting them.
 <br><br><br> Type of change: Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-5ba4480db6ba3b4b6758d4d4ab6adc9a0756f041d9b7a129191362c2fb67b530"> +5/-6</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/client/timebase_state.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated event handling to use the new event constants with <br>proper capitalization and fixed logic for event handling.
 <br><br><br> Type of change: Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-9377401fe8c6585d9e3cb535ac48e73e24e1e6794d28afe70544100f882ba2a7"> +11/-11</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/sample/clkmgr_test.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated event constants in the test sample to match the new <br>naming convention.
 <br><br> Type of change: <br>Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-39d8863e2f42d4a016139a23a804368bc9d910f36a372ee321de5dd51f85697e"> +32/-35</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/common/types.m4</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the event naming in the enum to use proper <br>capitalization.
 <br><br> Type of change: Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-5bdb52786941d27ed8aeaa79e7b1acb31c97e8183152bcf7c25f142f16c193e7"> +8/-8</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/common/msgq_tport.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added functionality to allow all users access to the message <br>queue and increased the buffer size.
 <br><br> Type of <br>change: Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-f32c94b4e13f3fd6030efce325e087e881869f19354fefafcb2aa2c07d4524e8"> +11/-4</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/common/msgq_tport.hpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Increased the maximum buffer length and added an option to <br>open the Rx queue with access for all users.
 <br><br> Type <br>of change: Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-d59048079f72a45d20ee4dd68e4e09f2f285cc89822279379085f2770ebb81f1"> +3/-3</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/proxy/client.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added an option to initialize the client with a flag for <br>message queue access control.
 <br><br> Type of change: <br>Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-b1809a7f57ce320b8f6227d91ead65466fedab069624ce8715be951f0c94bfb0"> +2/-2</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/proxy/client.hpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added a new parameter to the init function to control <br>message queue access.
 <br><br> Type of change: <br>Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-ee9362194fee0c7931623d1d1a2d24701323585879398fe7cf9d4fc12aad481c"> +1/-1</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/proxy/main.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added a command-line option to control access to the message <br>queue and handle initialization based on this option.
 <br><br><br> Type of change: Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-1c6438f9ef912bde1b43107a4bda086463ef2c3cc8d380b98ada626d1dfb343b"> +8/-2</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/utest/clockmanager.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated unit tests to use the new event naming conventions.
 <br><br><br> Type of change: Update_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-28560a354cbf8de0be5dfdc51ed292271c23e50a62638518af9e65125a9bbd1d"> +4/-4</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/utest/subscription.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated unit tests to use the new event naming conventions <br>and improved test coverage for subscription settings.
 <br><br><br> Type of change: Update_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-944ab61279d7f16c3531204f7691b4229ebcbff85514d7695751adfeed332745"> +4/-4</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/perl/clkmgr_test.pl</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added a comprehensive Perl test script for the Clock Manager <br>client.
 <br><br> Type of change: Create_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-3a2c533656da6ce40a239fd81d17b21c4313f3b8bd13281aa916024bd5064f6f"> +370/-0</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/python/clkmgr_test.py</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added a comprehensive Python test script for the Clock <br>Manager client.
 <br><br> Type of change: Create_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/241/files#diff-c2fa5eb89c17a0fa21256311015f54296963450d754ba9c08a3b22454b643fe4"> +325/-0</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

>### End of generated PR Summary by Smart DevOps Agent for GitHub