### PR TITLE
Add patch from Erez

### DIFF
--- a/clkmgr/TEST_clkmgr.md
+++ b/clkmgr/TEST_clkmgr.md
@@ -221,7 +221,7 @@ Options:
 Usage of c++ sample application (clkmgr_test):  
 ```bash  
 ~/libptpmgmt/clkmgr/sample# ./run_clkmgr_test.sh -h  
-Usage of ./clkmgr_test :  
+Usage of clkmgr_test :  
 Options:  
   -a subscribe to all time base indices  
      Default: timeBaseIndex: 1  
@@ -237,16 +237,12 @@ Options:
      Bit 0: EventGMOffset  
      Bit 1: EventSyncedToGM  
      Bit 2: EventASCapable  
-  -u gm offset upper limit (ns)  
+  -l gm offset threshold (ns)  
      Default: 100000 ns  
-  -l gm offset lower limit (ns)  
-     Default: -100000 ns  
   -i idle time (s)  
      Default: 1 s  
-  -m chrony offset upper limit (ns)  
+  -m chrony offset threshold (ns)  
      Default: 100000 ns  
-  -n chrony offset lower limit (ns)  
-     Default: -100000 ns  
   -t timeout in waiting notification event (s)  
      Default: 10 s
 ```

--- a/clkmgr/client/clockmanager.cpp
+++ b/clkmgr/client/clockmanager.cpp
@@ -149,8 +149,8 @@ send_connect:
     return ClientState::connect(DEFAULT_LIVENESS_TIMEOUT_IN_MS, &lastConnectTime);
 }
 
-static inline int _statusWait(int timeout, size_t timeBaseIndex,
-    ClockSyncData &clockSyncData)
+static inline enum StatusWaitResult _statusWait(int timeout,
+    size_t timeBaseIndex, ClockSyncData &clockSyncData)
 {
     // Check whether requested timeBaseIndex is subscribed or not
     auto &states = TimeBaseStates::getInstance();
@@ -189,8 +189,8 @@ static inline int _statusWait(int timeout, size_t timeBaseIndex,
     return SWREventDetected;
 }
 
-int ClockManager::statusWait(int timeout, size_t timeBaseIndex,
-    ClockSyncData &clockSyncData)
+enum StatusWaitResult ClockManager::statusWait(int timeout,
+    size_t timeBaseIndex, ClockSyncData &clockSyncData)
 {
     // Check whether connection between Proxy and Client is established or not
     if(!ClientState::get_connected()) {
@@ -200,8 +200,8 @@ int ClockManager::statusWait(int timeout, size_t timeBaseIndex,
     return _statusWait(timeout, timeBaseIndex, clockSyncData);
 }
 
-int ClockManager::statusWaitByName(int timeout, const string &timeBaseName,
-    ClockSyncData &clockSyncData)
+enum StatusWaitResult ClockManager::statusWaitByName(int timeout,
+    const string &timeBaseName, ClockSyncData &clockSyncData)
 {
     // Check whether connection between Proxy and Client is established or not
     if(!ClientState::get_connected()) {

--- a/clkmgr/client/clockmanager_c.cpp
+++ b/clkmgr/client/clockmanager_c.cpp
@@ -57,23 +57,24 @@ bool clkmgr_subscribe(const Clkmgr_Subscription *sub_c,
     return ClockManager::subscribe(newSub, timeBaseIndex, *data_c->data);
 }
 
-int clkmgr_statusWaitByName(int timeout, const char *timeBaseName,
-    Clkmgr_ClockSyncData *data_c)
+enum Clkmgr_StatusWaitResult clkmgr_statusWaitByName(int timeout,
+    const char *timeBaseName, Clkmgr_ClockSyncData *data_c)
 {
     if(!data_c)
-        return -1;
+        return Clkmgr_SWRInvalidArgument;
     size_t timeBaseIndex = 0;
     if(TimeBaseConfigurations::BaseNameToBaseIndex(timeBaseName, timeBaseIndex))
         return clkmgr_statusWait(timeout, timeBaseIndex, data_c);
-    return -1;
+    return Clkmgr_SWRInvalidArgument;
 }
 
-int clkmgr_statusWait(int timeout, size_t timeBaseIndex,
-    Clkmgr_ClockSyncData *data_c)
+enum Clkmgr_StatusWaitResult clkmgr_statusWait(int timeout,
+    size_t timeBaseIndex, Clkmgr_ClockSyncData *data_c)
 {
     if(timeBaseIndex == 0 || !data_c)
-        return -1;
-    return ClockManager::statusWait(timeout, timeBaseIndex, *data_c->data);
+        return Clkmgr_SWRInvalidArgument;
+    return static_cast<Clkmgr_StatusWaitResult>(ClockManager::statusWait(timeout,
+                timeBaseIndex, *data_c->data));
 }
 
 bool clkmgr_getTime(timespec *ts)

--- a/clkmgr/common/types.m4
+++ b/clkmgr/common/types.m4
@@ -69,7 +69,7 @@ enum Nm(ClockType) sz(`: uint32_t '){
 /**
 * Return value of statusWait API.
 */
-enum Nm(StatusWaitResult) sz(`: int32_t '){
+enum Nm(StatusWaitResult) sz(`: int8_t '){
     Nm(SWRLostConnection) = -2, /**< Lost connection to Proxy */
     Nm(SWRInvalidArgument) = -1, /**< Invalid argument */
     Nm(SWRNoEventDetected) = 0, /**< No event changes detected */

--- a/clkmgr/pub/clkmgr/clockmanager_c.h
+++ b/clkmgr/pub/clkmgr/clockmanager_c.h
@@ -69,11 +69,14 @@ bool clkmgr_subscribe(const Clkmgr_Subscription *sub_c,
  * until there is event changes occurs
  * @param[in] timeBaseName Name of the time base to be monitored
  * @param[out] data_c Pointer to the Clkmgr_ClockSyncData
- * @return true if there is event changes within the timeout period,
- *         and false otherwise
+ * @return Status of wait
+ * @li Clkmgr_SWRLostConnection: Lost connection to Proxy
+ * @li Clkmgr_SWRInvalidArgument: Invalid argument
+ * @li Clkmgr_SWRNoEventDetected: No event changes detected
+ * @li Clkmgr_SWREventDetected: At least an event change detected
  */
-int clkmgr_statusWaitByName(int timeout, const char *timeBaseName,
-    Clkmgr_ClockSyncData *data_c);
+enum Clkmgr_StatusWaitResult clkmgr_statusWaitByName(int timeout,
+    const char *timeBaseName, Clkmgr_ClockSyncData *data_c);
 
 /**
  * Waits for a specified timeout period for any event changes
@@ -82,11 +85,14 @@ int clkmgr_statusWaitByName(int timeout, const char *timeBaseName,
  * until there is event changes occurs
  * @param[in] timeBaseIndex Index of the time base to be monitored
  * @param[out] data_c Pointer to the Clkmgr_ClockSyncData
- * @return true if there is event changes within the timeout period,
- *         and false otherwise
+ * @return Status of wait
+ * @li Clkmgr_SWRLostConnection: Lost connection to Proxy
+ * @li Clkmgr_SWRInvalidArgument: Invalid argument
+ * @li Clkmgr_SWRNoEventDetected: No event changes detected
+ * @li Clkmgr_SWREventDetected: At least an event change detected
  */
-int clkmgr_statusWait(int timeout, size_t timeBaseIndex,
-    Clkmgr_ClockSyncData *data_c);
+enum Clkmgr_StatusWaitResult clkmgr_statusWait(int timeout,
+    size_t timeBaseIndex, Clkmgr_ClockSyncData *data_c);
 
 /**
  * Retrieve the time of the CLOCK_REALTIME

--- a/clkmgr/pub/clockmanager.h
+++ b/clkmgr/pub/clockmanager.h
@@ -99,8 +99,8 @@ class ClockManager
      * @li SWREventDetected: At least an event change detected
      * @note Calling this API will reset all event counts
      */
-    static int statusWaitByName(int timeout, const std::string &timeBaseName,
-        ClockSyncData &clockSyncData);
+    static enum StatusWaitResult statusWaitByName(int timeout,
+        const std::string &timeBaseName, ClockSyncData &clockSyncData);
 
     /**
      * Wait for status changes in the specified time-base by providing the
@@ -118,7 +118,7 @@ class ClockManager
      * @li SWREventDetected: At least an event change detected
      * @note Calling this API will reset all event counts
      */
-    static int statusWait(int timeout, size_t timeBaseIndex,
+    static enum StatusWaitResult statusWait(int timeout, size_t timeBaseIndex,
         ClockSyncData &clockSyncData);
 
     /**

--- a/clkmgr/sample/clkmgr_c_test.c
+++ b/clkmgr/sample/clkmgr_c_test.c
@@ -77,12 +77,16 @@ int main(int argc, char *argv[])
     int retval;
     int option;
 
+    const char *me = strrchr(argv[0], '/');
+    // Remove leading path
+    me = me == NULL ? argv[0] : me + 1;
+
     uint32_t eventMask = (Clkmgr_EventGMOffset | Clkmgr_EventSyncedToGM |
         Clkmgr_EventASCapable | Clkmgr_EventGMChanged);
     uint32_t compositeEventMask = (Clkmgr_EventGMOffset |
         Clkmgr_EventSyncedToGM | Clkmgr_EventASCapable);
 
-    while ((option = getopt(argc, argv, "aps:c:u:l:i:t:m:n:h")) != -1) {
+    while ((option = getopt(argc, argv, "aps:c:l:i:t:m:h")) != -1) {
         switch (option) {
         case 'a':
             subscribeAll = true;
@@ -139,10 +143,10 @@ int main(int argc, char *argv[])
                    "     Default: %d ns\n"
                    "  -t timeout in waiting notification event (s)\n"
                    "     Default: %d s\n",
-                   argv[0], eventMask,
+                   me, eventMask,
                    compositeEventMask,
-                   ptp4lClockOffsetThreshold, chronyClockOffsetThreshold,
-                   idleTime, timeout);
+                   ptp4lClockOffsetThreshold, idleTime,
+                   chronyClockOffsetThreshold, timeout);
             return EXIT_SUCCESS;
         default:
             printf("Usage of %s :\n"
@@ -169,10 +173,10 @@ int main(int argc, char *argv[])
                    "     Default: %d ns\n"
                    "  -t timeout in waiting notification event (s)\n"
                    "     Default: %d s\n",
-                   argv[0], eventMask,
+                   me, eventMask,
                    compositeEventMask,
-                   ptp4lClockOffsetThreshold, chronyClockOffsetThreshold,
-                   idleTime, timeout);
+                   ptp4lClockOffsetThreshold, idleTime,
+                   chronyClockOffsetThreshold, timeout);
             return EXIT_FAILURE;
         }
     }

--- a/clkmgr/sample/clkmgr_test.cpp
+++ b/clkmgr/sample/clkmgr_test.cpp
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <vector>
+#include <cstring>
 
 #include <clockmanager.h>
 
@@ -79,6 +80,10 @@ int main(int argc, char *argv[])
     int retval;
     int option;
 
+    const char *me = strrchr(argv[0], '/');
+    // Remove leading path
+    me = me == nullptr ? argv[0] : me + 1;
+
     std::uint32_t event2Sub = {
         (EventGMOffset | EventSyncedToGM | EventASCapable |
         EventGMChanged)
@@ -98,7 +103,7 @@ int main(int argc, char *argv[])
     uint64_t gmClockUUID;
     std::map<size_t, ClockSyncSubscription> overallSub;
 
-    while ((option = getopt(argc, argv, "aps:c:u:l:i:t:n:m:h")) != -1) {
+    while ((option = getopt(argc, argv, "aps:c:l:i:t:m:h")) != -1) {
         switch (option) {
         case 'a':
             subscribeAll = true;
@@ -133,7 +138,7 @@ int main(int argc, char *argv[])
             }
             break;
         case 'h':
-            std::cout << "Usage of " << argv[0] << " :\n"
+            std::cout << "Usage of " << me << " :\n"
                 "Options:\n"
                 "  -a subscribe to all time base indices\n"
                 "     Default: timeBaseIndex: 1\n"
@@ -150,16 +155,16 @@ int main(int argc, char *argv[])
                 "     Bit 1: EventSyncedToGM\n"
                 "     Bit 2: EventASCapable\n"
                 "  -l gm offset threshold (ns)\n"
-                "     Default: " << ptp4lClockOffsetThreshold << " ns\n"
+                "     Default: " << std::dec << ptp4lClockOffsetThreshold << " ns\n"
                 "  -i idle time (s)\n"
                 "     Default: " << idleTime << " s\n"
                 "  -m chrony offset threshold (ns)\n"
-                "     Default: " << std::dec << chronyClockOffsetThreshold << " ns\n"
+                "     Default: " << chronyClockOffsetThreshold << " ns\n"
                 "  -t timeout in waiting notification event (s)\n"
                 "     Default: " << timeout << " s\n";
             return EXIT_SUCCESS;
         default:
-            std::cerr << "Usage of " << argv[0] << " :\n"
+            std::cerr << "Usage of " << me << " :\n"
                 "Options:\n"
                 "  -a subscribe to all time base indices\n"
                 "     Default: timeBaseIndex: 1\n"
@@ -176,11 +181,11 @@ int main(int argc, char *argv[])
                 "     Bit 1: EventSyncedToGM\n"
                 "     Bit 2: EventASCapable\n"
                 "  -l gm offset threshold (ns)\n"
-                "     Default: " << ptp4lClockOffsetThreshold << " ns\n"
+                "     Default: " << std::dec << ptp4lClockOffsetThreshold << " ns\n"
                 "  -i idle time (s)\n"
                 "     Default: " << idleTime << " s\n"
                 "  -m chrony offset threshold (ns)\n"
-                "     Default: " << std::dec << chronyClockOffsetThreshold << " ns\n"
+                "     Default: " << chronyClockOffsetThreshold << " ns\n"
                 "  -t timeout in waiting notification event (s)\n"
                 "     Default: " << timeout << " s\n";
             return EXIT_FAILURE;

--- a/clkmgr/utest/Makefile
+++ b/clkmgr/utest/Makefile
@@ -11,55 +11,61 @@
 ifdef GTEST_LIB_FLAGS
 
 CLKMGR_CLIENT_UTEST:=$(CLKMGR_UTEST_DIR)/utest_client
-CLKMGR_CLIENT_SRC:=timebase_configs subscription client_state event
-CLKMGR_CLIENT_OBJS:=$(foreach n,$(CLKMGR_CLIENT_SRC),$(CLKMGR_UTEST_DIR)/$n.o)
+CLKMGR_CLIENT_UTEST_SRCS:=timebase_configs subscription client_state event
+CLKMGR_CLIENT_UTEST_OBJS:=$(foreach n,$(CLKMGR_CLIENT_UTEST_SRCS),\
+  $(CLKMGR_UTEST_DIR)/$n.o)
 
 CLKMGR_COMMON_UTEST:=$(CLKMGR_UTEST_DIR)/utest_common
-CLKMGR_COMMON_SRC:=buffer
-CLKMGR_COMMON_OBJS:=$(foreach n,$(CLKMGR_COMMON_SRC),$(CLKMGR_UTEST_DIR)/$n.o)
+CLKMGR_COMMON_UTEST_SRCS:=buffer
+CLKMGR_COMMON_UTEST_OBJS:=$(foreach n,$(CLKMGR_COMMON_UTEST_SRCS),\
+  $(CLKMGR_UTEST_DIR)/$n.o)
 
 CLKMGR_MSG_UTEST:=$(CLKMGR_UTEST_DIR)/utest_message
-CLKMGR_MSG_SRC:=connect_msg subscribe_msg notification_msg message
-CLKMGR_MSG_UTEST_OBJS:=$(foreach n,$(CLKMGR_MSG_SRC),$(CLKMGR_UTEST_DIR)/$n.o)
+CLKMGR_MSG_UTEST_SRCS:=connect_msg subscribe_msg notification_msg message
+CLKMGR_MSG_UTEST_OBJS:=$(foreach n,$(CLKMGR_MSG_UTEST_SRCS),\
+  $(CLKMGR_UTEST_DIR)/$n.o)
 CLKMGR_MSG_SRCS:=$(wildcard $(CLKMGR_DIR)/*/*_msg.cpp)
-CLKMGR_MSG_OBJS:=$(CLKMGR_MSG_SRCS:.cpp=.o)
-CLKMGR_MSG_OBJS+=$(addsuffix .o, $(addprefix $(CLKMGR_COMMON_DIR)/, message\
-msgq_tport print termin sighandler) $(addprefix $(CLKMGR_CLIENT_DIR)/,subscription))
+CLKMGR_MSG_OBJS:=$(CLKMGR_MSG_SRCS:.cpp=.o) $(addsuffix .o,\
+  $(addprefix $(CLKMGR_COMMON_DIR)/,message msgq_tport print termin sighandler)\
+  $(addprefix $(CLKMGR_CLIENT_DIR)/,subscription))
 
 CLKMGR_CONFIG_PARSER_UTEST:=$(CLKMGR_UTEST_DIR)/utest_config_parser
-CLKMGR_CONFIG_PARSER_SRC:=config_parser
-CLKMGR_CONFIG_PARSER_UTEST_OBJS:=$(foreach n, $(CLKMGR_CONFIG_PARSER_SRC),\
-  $(CLKMGR_UTEST_DIR)/$n.o)
-CLKMGR_CONFIG_PARSER_SRCS:=$(wildcard $(CLKMGR_DIR)/proxy/config_parser.cpp)
-CLKMGR_CONFIG_PARSER_OBJS:=$(CLKMGR_CONFIG_PARSER_SRCS:.cpp=.o)
-CLKMGR_CONFIG_PARSER_OBJS+=$(addsuffix .o, $(addprefix $(CLKMGR_COMMON_DIR)/,\
-print termin) $(addprefix $(SRC)/, jsonParser))
+CLKMGR_CONFIG_PARSER_UTEST_SRCS:=config_parser
+CLKMGR_CONFIG_PARSER_UTEST_OBJS:=$(foreach n,\
+  $(CLKMGR_CONFIG_PARSER_UTEST_SRCS),$(CLKMGR_UTEST_DIR)/$n.o)
+CLKMGR_CONFIG_PARSER_OBJS:=$(addsuffix .o,\
+  $(SRC)/jsonParser $(CLKMGR_DIR)/proxy/config_parser\
+  $(addprefix $(CLKMGR_COMMON_DIR)/,print termin))
 
 CLKMGR_API_UTEST:=$(CLKMGR_UTEST_DIR)/utest_api
-CLKMGR_API_SRC:=clockmanager
-CLKMGR_API_UTEST_OBJS:=$(foreach n,$(CLKMGR_API_SRC),$(CLKMGR_UTEST_DIR)/$n.o)
-CLKMGR_API_SRCS:=$(CLKMGR_CLIENT_DIR)/clockmanager.cpp
-CLKMGR_API_OBJS:=$(CLKMGR_API_SRCS:.cpp=.o)
-CLKMGR_API_OBJS+=$(addsuffix .o, $(addprefix $(CLKMGR_COMMON_DIR)/, print termin)\
-$(addprefix $(CLKMGR_CLIENT_DIR)/, timebase_configs subscription clock_event))
+CLKMGR_API_UTEST_SRCS:=clockmanager
+CLKMGR_API_UTEST_OBJS:=$(foreach n,$(CLKMGR_API_UTEST_SRCS),\
+  $(CLKMGR_UTEST_DIR)/$n.o)
+CLKMGR_API_OBJS+=$(addsuffix .o,\
+  $(CLKMGR_CLIENT_DIR)/clockmanager\
+  $(addprefix $(CLKMGR_COMMON_DIR)/,print termin)\
+  $(addprefix $(CLKMGR_CLIENT_DIR)/,timebase_configs subscription clock_event))
 
 $(CLKMGR_UTEST_DIR)/%.o: $(CLKMGR_UTEST_DIR)/%.cpp | $(COMP_DEPS)
 	$(Q_CC)$(CXX) $(CXXFLAGS_UTEST) $(CLKMGR_CXXFLAGS) $(GTEST_INC_FLAGS)\
 	  -include $(HAVE_GTEST_HEADER) -c -o $@ $<
-$(CLKMGR_CLIENT_UTEST): $(OBJ_DIR)/utest_m.o $(CLKMGR_CLIENT_OBJS) \
+
+$(CLKMGR_CLIENT_UTEST): $(OBJ_DIR)/utest_m.o $(CLKMGR_CLIENT_UTEST_OBJS) \
 	$(CLKMGR_LIB_A) | $(CLKMGR_LIB_LA)
 	$(Q_LD)$(CXX) $(LDFLAGS) $^ $(LOADLIBES) $(LDLIBS) $(CLKMGR_LDLIBS)\
 	  $(GTEST_LIB_FLAGS) -o $@
 utest_clkmgr_client: $(HEADERS_GEN_COMP) $(CLKMGR_CLIENT_UTEST)
 	$(call Q_UTEST,ClkMgr client C++)$(UVGD)$(CLKMGR_CLIENT_UTEST)\
 	  $(GTEST_NO_COL) $(GTEST_FILTERS)
-$(CLKMGR_COMMON_UTEST): $(OBJ_DIR)/utest_m.o $(CLKMGR_COMMON_OBJS) \
+
+$(CLKMGR_COMMON_UTEST): $(OBJ_DIR)/utest_m.o $(CLKMGR_COMMON_UTEST_OBJS) \
 	$(CLKMGR_LIB_A) | $(CLKMGR_LIB_LA)
 	$(Q_LD)$(CXX) $(LDFLAGS) $^ $(LOADLIBES) $(LDLIBS) $(CLKMGR_LDLIBS)\
 	  $(GTEST_LIB_FLAGS) -o $@
 utest_clkmgr_common: $(HEADERS_GEN_COMP) $(CLKMGR_COMMON_UTEST)
 	$(call Q_UTEST,ClkMgr common C++)$(UVGD)$(CLKMGR_COMMON_UTEST)\
 	  $(GTEST_NO_COL) $(GTEST_FILTERS)
+
 $(CLKMGR_MSG_UTEST): $(OBJ_DIR)/utest_m.o $(CLKMGR_MSG_UTEST_OBJS)\
 	$(CLKMGR_MSG_OBJS)
 	$(Q_LD)$(CXX) $(LDFLAGS) $^ $(LOADLIBES) $(LDLIBS) $(CLKMGR_LDLIBS)\
@@ -67,6 +73,7 @@ $(CLKMGR_MSG_UTEST): $(OBJ_DIR)/utest_m.o $(CLKMGR_MSG_UTEST_OBJS)\
 utest_clkmgr_message: $(HEADERS_GEN_COMP) $(CLKMGR_MSG_UTEST)
 	$(call Q_UTEST,ClkMgr message C++)$(UVGD)$(CLKMGR_MSG_UTEST)\
 	  $(GTEST_NO_COL) $(GTEST_FILTERS)
+
 $(CLKMGR_CONFIG_PARSER_UTEST): $(OBJ_DIR)/utest_m.o\
 	$(CLKMGR_CONFIG_PARSER_UTEST_OBJS) $(CLKMGR_CONFIG_PARSER_OBJS)
 	$(Q_LD)$(CXX) $(LDFLAGS) $^ $(LOADLIBES) $(LDLIBS) $(CLKMGR_LDLIBS)\
@@ -74,12 +81,13 @@ $(CLKMGR_CONFIG_PARSER_UTEST): $(OBJ_DIR)/utest_m.o\
 utest_clkmgr_config_parser: $(HEADERS_GEN_COMP) $(CLKMGR_CONFIG_PARSER_UTEST)
 	$(call Q_UTEST,ClkMgr proxy C++)$(UVGD)$(CLKMGR_CONFIG_PARSER_UTEST)\
 	  $(GTEST_NO_COL) $(GTEST_FILTERS)
+
 $(CLKMGR_API_UTEST): $(OBJ_DIR)/utest_m.o $(CLKMGR_API_UTEST_OBJS)\
 	$(CLKMGR_API_OBJS)
 	$(Q_LD)$(CXX) $(LDFLAGS) $^ $(LOADLIBES) $(LDLIBS) $(CLKMGR_LDLIBS)\
 	  $(GTEST_LIB_FLAGS) -o $@
 utest_clkmgr_api: $(HEADERS_GEN_COMP) $(CLKMGR_API_UTEST)
-	$(call Q_UTEST,ClkMgr api C++)$(UVGD)$(CLKMGR_API_UTEST)\
+	$(call Q_UTEST,ClkMgr API C++)$(UVGD)$(CLKMGR_API_UTEST)\
 	  $(GTEST_NO_COL) $(GTEST_FILTERS)
 
 endif #GTEST_LIB_FLAGS

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -25,7 +25,7 @@ RUN if [ -f /etc/apt/sources.list.d/debian.sources ];then\
     debhelper coreutils sudo dh-lua dh-make-perl dh-exec git procps dh-php\
     build-essential ncurses-bin dlocate dialog lsb-release quilt apt-file\
     libtool libtool-bin swig golang install-info doxygen graphviz\
-    qemu-user-static distro-info chrpath patchelf tree\
+    qemu-user-static distro-info chrpath patchelf tree tclx8.4\
     lua5.1 lua5.2 lua5.3 dh-python python3-dev php-dev m4 perl ruby\
     astyle cppcheck universal-ctags libtest-class-perl ruby-test-unit lua-unit\
     ruby-test-unit-context ruby-test-unit-notify libfile-touch-perl phpunit\

--- a/gentoo/Dockerfile.1
+++ b/gentoo/Dockerfile.1
@@ -23,7 +23,7 @@ RUN emerge-webrsync && emerge -tvuD @world &&\
     dev-lang/lua dev-lua/luaposix dev-lang/php dev-lang/tcl sys-devel/gcc\
     dev-util/cppcheck media-gfx/graphviz perl-core/Test-Simple\
     app-text/texlive-core dev-texlive/texlive-fontutils net-misc/chrony\
-    dev-util/quilt app-text/cmark dev-tcltk/tcllib &&\
+    dev-util/quilt app-text/cmark dev-tcltk/tcllib dev-tcltk/tclx &&\
     echo "$USER ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers &&\
     sed -i 's/^enable_dl\s*=\s*Off/enable_dl = On/' /etc/php/*/php.ini &&\
     mkdir -p /t0 && cd /t0 && git clone https://github.com/linux-rt/librtpi &&\

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -17,7 +17,7 @@ RUN dnf install -y gcc gcc-c++ libtool libtool-ltdl make cmake git pkgconfig\
     lua lua-devel python3-devel php python3 which gtest-devel gtest golang\
     perl-devel perl-ExtUtils-Embed lua-posix tcl tcl-devel clang openssl-libs\
     openssl-devel libgcrypt-devel gnutls-devel nettle-devel perl-Test-Class\
-    libfastjson libfastjson-devel json-c-devel m4 rubygem-test-unit gdb\
+    libfastjson libfastjson-devel json-c-devel m4 rubygem-test-unit gdb tclx\
     texlive-epstopdf ghostscript php-phpunit-PHPUnit perl-File-Touch jq\
     chrpath patchelf discount gmock-devel cppcheck chrony quilt cmark tcllib\
     && dnf clean all &&\

--- a/wrappers/perl/clkmgr_test.pl
+++ b/wrappers/perl/clkmgr_test.pl
@@ -16,6 +16,7 @@
 
 use threads;
 use threads::shared;
+use File::Basename;
 use POSIX;
 use Time::HiRes;
 use Getopt::Std;
@@ -71,12 +72,13 @@ sub main
 
     my @overallSub; # Array of ClkMgrLib::ClockSyncSubscription
 
-    my $ret = getopts('aps:c:u:l:i:t:n:m:h');
+    my $ret = getopts('aps:c:l:i:t:m:h');
     if($opt_h || !$ret) {
         my $event2SubHex = sprintf '0x%x', $event2Sub;
         my $composite_eventHex = sprintf '0x%x', $composite_event;
+        my $name = basename $0;
         my $help = <<"END_MESSAGE";
-Usage of $0:
+Usage of $name :
 Options:
   -a subscribe to all time base indices
      Default: timeBaseIndex: 1

--- a/wrappers/php/clkmgr_test.php
+++ b/wrappers/php/clkmgr_test.php
@@ -48,7 +48,7 @@ function clockManagerGetTime(): void
 
 function main(): void
 {
-    global $signal_flag;
+    global $signal_flag, $argv;
     $ptp4lClockOffsetThreshold = 100000;
     $chronyClockOffsetThreshold = 100000;
     $subscribeAll = false;
@@ -62,12 +62,13 @@ function main(): void
     $ptp4lSub = new PTPClockSubscription();
     $chronySub = new SysClockSubscription();
     $overallSub = []; # Array of ClockSyncSubscription
-    $options = getopt('aps:c:u:l:i:t:n:m:h');
+    $options = getopt('aps:c:l:i:t:m:h');
     if(array_key_exists('h', $options)) {
         $event2SubHex = dechex($event2Sub);
         $composite_eventHex = dechex($composite_event);
+        $me = basename($argv[0]);
         echo <<< END
-        Usage of $0:
+        Usage of $me :
         Options:
           -a subscribe to all time base indices
              Default: timeBaseIndex: 1

--- a/wrappers/python/clkmgr_test.py
+++ b/wrappers/python/clkmgr_test.py
@@ -62,7 +62,7 @@ def ClockManagerGetTime():
 
 def usage():
     print('''
-Usage of {}:
+Usage of {} :
 Options:
   -a subscribe to all time base indices
      Default: timeBaseIndex: 1
@@ -86,7 +86,7 @@ Options:
      Default: {} ns
   -t timeout in waiting notification event (s)
      Default: {} s
-'''[:-1].format(sys.argv[0], hex(event2Sub),
+'''[:-1].format(os.path.basename(sys.argv[0]), hex(event2Sub),
     hex(composite_event), ptp4lClockOffsetThreshold,
     idleTime, chronyClockOffsetThreshold, timeout))
 
@@ -95,7 +95,7 @@ def main():
         ptp4lClockOffsetThreshold, idleTime, timeout, \
         chronyClockOffsetThreshold
     try:
-        opts, args = getopt.gnu_getopt(sys.argv[1:], 'aps:c:u:l:i:t:n:m:h')
+        opts, args = getopt.gnu_getopt(sys.argv[1:], 'aps:c:l:i:t:m:h')
     except getopt.GetoptError as err:
         print(err)
         usage()

--- a/wrappers/ruby/clkmgr_test.rb
+++ b/wrappers/ruby/clkmgr_test.rb
@@ -55,7 +55,7 @@ end
 
 def usage
     puts <<-EOF
-Usage of #{ $0 }
+Usage of #{ File.basename($0) } :
 Options
   -a subscribe to all time base indices
      Default: timeBaseIndex: 1
@@ -89,11 +89,9 @@ def main
       [ '--p', '-p', GetoptLong::NO_ARGUMENT ],
       [ '--s', '-s', GetoptLong::REQUIRED_ARGUMENT ],
       [ '--c', '-c', GetoptLong::REQUIRED_ARGUMENT ],
-      [ '--u', '-u', GetoptLong::REQUIRED_ARGUMENT ],
       [ '--l', '-l', GetoptLong::REQUIRED_ARGUMENT ],
       [ '--i', '-i', GetoptLong::REQUIRED_ARGUMENT ],
       [ '--t', '-t', GetoptLong::REQUIRED_ARGUMENT ],
-      [ '--n', '-n', GetoptLong::REQUIRED_ARGUMENT ],
       [ '--m', '-m', GetoptLong::REQUIRED_ARGUMENT ],
       [ '--h', '-h', GetoptLong::NO_ARGUMENT ],
     )

--- a/wrappers/tcl/clkmgr_test.tcl
+++ b/wrappers/tcl/clkmgr_test.tcl
@@ -1,0 +1,427 @@
+#!/usr/bin/tclsh
+# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-FileCopyrightText: Copyright © 2024 Intel Corporation.
+#
+# Test Tcl Clock Manager client
+#
+# @author Christopher Hall <christopher.s.hall@@intel.com>
+# @copyright © 2024 Intel Corporation.
+#
+# @note This is a sample code, not a product! You should use it as a reference.
+#
+# To run in development environment:
+# LD_PRELOAD=../../.libs/libclkmgr.so TCLLIBPATH=. ./clkmgr_test.tcl
+#
+# Run ./pkgIndex_tcl.sh to create pkgIndex.tcl
+#
+# This code also need: tcllib, tclx
+#
+###############################################################################
+
+package require Tclx
+package require cmdline
+package require clkmgr
+
+set signal_flag 0
+set index [list]
+clkmgr::ClockSyncData clockSyncData
+clkmgr::PTPClockSubscription ptp4lSub
+clkmgr::SysClockSubscription chronySub
+
+proc signal_handler {} {
+    global signal_flag
+    puts " Exit ..."
+    set signal_flag 1
+}
+
+proc isPositiveValue { optarg errorMessage } {
+    set ret [expr $optarg ]
+    if { $ret > 0 } {
+        return $ret
+    }
+    puts $errorMessage
+    exit 2
+}
+
+proc ClockManagerGetTime {} {
+    set ts [ clkmgr::timespec ]
+    if { [ clkmgr::ClockManager_getTime $ts ] } {
+        puts [format "\[clkmgr] Current Time of CLOCK_REALTIME: %ld ns" \
+            [expr ( [ $ts cget -tv_sec ] * 1000000000 ) +\
+            [ $ts cget -tv_nsec ]]]
+    } else {
+        puts "clock_gettime failed"
+    }
+}
+
+proc main {} {
+    global argv argv0 index subscribeAll event2Sub composite_event\
+        clockSyncData ptp4lSub chronySub idleTime timeout
+    # index list of indexes to subscribe
+    set event2Sub [expr $clkmgr::EventGMOffset | $clkmgr::EventSyncedToGM |\
+        $clkmgr::EventASCapable | $clkmgr::EventGMChanged ]
+    set composite_event [expr $clkmgr::EventGMOffset |\
+        $clkmgr::EventSyncedToGM | $clkmgr::EventASCapable ]
+    set options {
+        {h}
+        {a}
+        {p}
+        # event2Sub
+        {s.arg "" }
+        # composite_event
+        {c.arg "" }
+        # ptp4lClockOffsetThreshold
+        {l.arg 100000}
+        # idleTime
+        {i.arg 1}
+        # chronyClockOffsetThreshold
+        {m.arg 100000}
+        # timeout
+        {t.arg 10}
+    }
+    try {
+        array set params [::cmdline::getoptions argv $options "" ]
+    } trap {CMDLINE USAGE} {} {
+        puts "Invalid option $argv"
+        set help 1
+    }
+    if { [ info exist help ] || $params(h) } {
+    puts "
+Usage of $argv0:
+Options:
+  -a subscribe to all time base indices
+     Default: timeBaseIndex: 1
+  -p enable user to subscribe to specific time base indices
+  -s subscribe_event_mask
+     Default: 0x[format %x $event2Sub ]
+     Bit 0: EventGMOffset
+     Bit 1: EventSyncedToGM
+     Bit 2: EventASCapable
+     Bit 3: EventGMChanged
+  -c composite_event_mask
+     Default: 0x[format %x $composite_event ]
+     Bit 0: EventGMOffset
+     Bit 1: EventSyncedToGM
+     Bit 2: EventASCapable
+  -l gm offset threshold (ns)
+     Default: 100000 ns
+  -i idle time (s)
+     Default: 1 s
+  -m chrony offset threshold (ns)
+     Default: 100000 ns
+  -t timeout in waiting notification event (s)
+     Default: 10 s"
+        if { [ info exist help ] } {
+            exit 2
+        }
+        return
+    }
+    set subscribeAll $params(a)
+    set userInput [expr $params(p) && !$subscribeAll ]
+    if { [string length $params(s)] > 0} {
+        try {
+            set event2Sub [expr $params(s) ]
+        } trap {} {} {
+            puts "use "-s" with a number"
+            exit 2
+        }
+    }
+    if { [string length $params(c)] > 0} {
+        try {
+            set composite_event [expr $params(c) ]
+        } trap {} {} {
+            puts "use "-c" with a number"
+            exit 2
+        }
+    }
+    set ptp4lClockOffsetThreshold [ isPositiveValue $params(l)\
+        "Invalid ptp4l GM Offset threshold!" ]
+    set idleTime [ isPositiveValue $params(i) "Invalid idle time!" ]
+    set timeout [ isPositiveValue $params(t) "Invalid timeout!" ]
+    set chronyClockOffsetThreshold [ isPositiveValue $params(m)\
+        "Invalid Chrony Offset threshold!" ]
+    signal trap SIGINT signal_handler
+    signal trap SIGTERM signal_handler
+    signal trap SIGHUP signal_handler
+    ptp4lSub setEventMask $event2Sub
+    ptp4lSub setClockOffsetThreshold $ptp4lClockOffsetThreshold
+    ptp4lSub setCompositeEventMask $composite_event
+    chronySub setClockOffsetThreshold $chronyClockOffsetThreshold
+    puts [format "\[clkmgr] set subscribe event : 0x%x"\
+        [ ptp4lSub getEventMask ]]
+    puts [format "\[clkmgr] set composite event : 0x%x"\
+        [ ptp4lSub getCompositeEventMask ]]
+    puts "GM Offset threshold: $ptp4lClockOffsetThreshold ns"
+    puts "Chrony Offset threshold: $chronyClockOffsetThreshold ns"
+    if { $userInput } {
+        puts -nonewline "Enter the time base indices to subscribe\
+            comma-separated, default is 1 : "
+        flush stdout
+        set line [ gets stdin ]
+        if { [string length $line] == 0} {
+            puts "Invalid input. Using default time base index 1."
+        } else {
+            try {
+                set idx [expr $line ]
+            } trap {} {} {
+                puts "$line is not a number"
+                exit 2
+            }
+            lappend index $idx
+        }
+    }
+    set ret [ main_body ]
+    clkmgr::ClockManager_disconnect
+    if { $ret > 0 } {
+        exit 2
+    }
+}
+
+proc main_body {} {
+    global signal_flag index subscribeAll event2Sub composite_event\
+           clockSyncData ptp4lSub chronySub idleTime timeout
+    # overallSub # Array of clkmgr::ClockSyncSubscription
+    if { ! [ clkmgr::ClockManager_connect ] } {
+        puts "\[clkmgr] failure in connecting !!!"
+        return 2
+    }
+    sleep 1
+    puts "\[clkmgr] List of available clock:"
+    # Print out each member of the Time Base configuration
+    set size [ clkmgr::TimeBaseConfigurations_size ]
+     for {set i 1} {$i <= $size} {incr i} {
+        set cfg [ clkmgr::TimeBaseConfigurations_getRecord $i ]
+        set idx [ $cfg index ]
+        puts "TimeBaseIndex: $idx"
+        puts "timeBaseName: [ $cfg name ]"
+        set subscribe [ clkmgr::ClockSyncSubscription ]
+        if { [ $cfg havePtp ] } {
+            set ptp [ $cfg ptp ]
+            puts "interfaceName: [ $ptp ifName ]"
+            puts "transportSpecific: [ $ptp transportSpecific ]"
+            puts "domainNumber: [ $ptp domainNumber ]"
+            $subscribe setPtpSubscription ptp4lSub
+        }
+        if { [ $cfg haveSysClock ] } {
+            $subscribe setSysSubscription chronySub
+        }
+        set overallSub($idx) $subscribe
+        puts ""
+        if { $subscribeAll } {
+            lappend index $idx
+        }
+    }
+
+    # Default
+    if { [ llength $index ] == 0 } {
+        lappend index 1
+    }
+
+    set hd2 "|[string repeat - 27]|[string repeat - 24]|"
+    foreach idx $index {
+        puts "subscribe to time base index: $idx"
+        if { ! [ clkmgr::ClockManager_subscribe $overallSub($idx)\
+            $idx clockSyncData ] } {
+            puts "\[clkmgr] Failure in subscribing to clkmgr Proxy !!!"
+            return 2
+        }
+        puts [format "\[clkmgr]\[%.3f] Obtained data from %s"\
+            [expr [clock milliseconds ] / 1000.0 ]\
+            "Subscription Event:"]
+        ClockManagerGetTime
+        puts $hd2
+        puts [format "| %-25s | %-22s |" "Event" "Event Status" ]
+        set ptpClock [ clockSyncData getPtp ]
+        set sysClock [ clockSyncData getSysClock ]
+        if { $event2Sub != 0 } {
+            puts $hd2
+            if { $event2Sub & $clkmgr::EventGMOffset } {
+                puts [format "| %-25s | %-22d |" "offset_in_range"\
+                    [ $ptpClock isOffsetInRange ]]
+            }
+            if { $event2Sub & $clkmgr::EventSyncedToGM } {
+                puts [format "| %-25s | %-22d |" "synced_to_primary_clock"\
+                    [ $ptpClock isSyncedWithGm ]]
+            }
+            if { $event2Sub & $clkmgr::EventASCapable } {
+                puts [format "| %-25s | %-22d |" "as_capable"\
+                    [ $ptpClock isAsCapable ]]
+            }
+            if { $event2Sub & $clkmgr::EventGMChanged } {
+                puts [format "| %-25s | %-22d |" "gm_Changed"\
+                    [ $ptpClock isGmChanged ]]
+            }
+        }
+        puts $hd2
+        set gmClockUUID [ $ptpClock getGmIdentity ]
+        # Copy the uint64_t into the array
+        for {set i 0} {$i < 8} {incr i} {
+            set id($i) [expr ($gmClockUUID >> (8 * (7 - $i))) & 0xff ]
+        }
+        puts [format "| %-25s | %02x%02x%02x.%02x%02x.%02x%02x%02x     |"\
+            "GM UUID" $id(0) $id(1) $id(2) $id(3) $id(4) $id(5) $id(6) $id(7) ]
+        puts [format "| %-25s | %-19ld ns |" "clock_offset"\
+            [ $ptpClock getClockOffset ]]
+        puts [format "| %-25s | %-19ld ns |" "notification_timestamp"\
+            [ $ptpClock getNotificationTimestamp ]]
+        puts [format "| %-25s | %-19ld us |" "gm_sync_interval"\
+            [ $ptpClock getSyncInterval ]]
+        puts $hd2
+        if { $composite_event != 0 } {
+            puts [format "| %-25s | %-22d |" "composite_event"\
+                [ $ptpClock isCompositeEventMet ]]
+            if { $composite_event & $clkmgr::EventGMOffset } {
+                puts [format "| - %-23s | %-22s |" "offset_in_range" "" ]
+            }
+            if { $composite_event & $clkmgr::EventSyncedToGM } {
+                puts [format "| - %-19s | %-22s |"\
+                    "synced_to_primary_clock" "" ]
+            }
+            if { $composite_event & $clkmgr::EventASCapable } {
+                puts [format "| - %-23s | %-22s |" "as_capable" "" ]
+            }
+            puts $hd2
+        }
+        puts ""
+        puts $hd2
+        puts [format "| %-25s | %-22d |" "chrony_offset_in_range"\
+            [ $sysClock isOffsetInRange ]]
+        puts $hd2
+        puts [format "| %-25s | %-19ld ns |" "chrony_clock_offset"\
+            [ $sysClock getClockOffset ]]
+        puts [format "| %-25s | %-19lx    |" "chrony_clock_reference_id"\
+            [ $sysClock getGmIdentity ]]
+        puts [format "| %-25s | %-19ld us |" "chrony_polling_interval"\
+            [ $sysClock getSyncInterval ]]
+        puts $hd2
+        puts ""
+    }
+    sleep 1
+
+    set hd2l "|[string repeat - 27]|[string repeat - 28]|"
+    set hd3b "| %-25s | %-12d | %-11d |"
+    set hd3 "|[string repeat - 27]|[string repeat - 14]|[string repeat - 13]|"
+
+    while { !$signal_flag } {
+        foreach idx $index {
+            if { $signal_flag } {
+                return 0
+            }
+            puts [format "\[clkmgr]\[%.3f] Waiting Notification from %s"\
+                [expr [clock milliseconds ] / 1000.0 ]\
+                "time base index $idx ..."]
+            set retval [ clkmgr::ClockManager_statusWait $timeout\
+                $idx clockSyncData ]
+            if { !$retval } {
+                puts [format "\[clkmgr]\[%.3f] No event status changes %s"\
+                    [expr [clock milliseconds ] / 1000.0 ]\
+                    "identified in $timeout seconds."]
+                puts ""
+                puts [format "\[clkmgr]\[%.3f] sleep for %s"\
+                    [expr [clock milliseconds ] / 1000.0 ]\
+                    "$idleTime seconds..."]
+                puts ""
+                if { $signal_flag } {
+                    return 0
+                }
+                sleep $idleTime
+                continue
+            } elseif { $retval < 0 } {
+                puts [format "\[clkmgr]\[%.3f] Terminating: %s"\
+                    [expr [clock milliseconds ] / 1000.0 ]\
+                    "lost connection to clkmgr Proxy"]
+                return 0
+            }
+            puts [format "\[clkmgr]\[%.3f] Obtained data from %s"\
+                [expr [clock milliseconds ] / 1000.0 ]\
+                "Notification Event:"]
+            ClockManagerGetTime
+            puts $hd3
+            puts [format "| %-25s | %-12s | %-11s |" "Event"\
+                "Event Status" "Event Count" ]
+            set ptpClock [ clockSyncData getPtp ]
+            set sysClock [ clockSyncData getSysClock ]
+            if { $event2Sub != 0 } {
+                puts $hd3
+                if { $event2Sub & $clkmgr::EventGMOffset } {
+                    puts [format $hd3b "offset_in_range"\
+                        [ $ptpClock isOffsetInRange ]\
+                        [ $ptpClock getOffsetInRangeEventCount ]]
+                }
+                if { $event2Sub & $clkmgr::EventSyncedToGM } {
+                    puts [format $hd3b "synced_to_primary_clock"\
+                        [ $ptpClock isSyncedWithGm ]\
+                        [ $ptpClock getSyncedWithGmEventCount ]]
+                }
+                if { $event2Sub & $clkmgr::EventASCapable } {
+                    puts [format $hd3b "as_capable"\
+                        [ $ptpClock isAsCapable ]\
+                        [ $ptpClock getAsCapableEventCount ]]
+                }
+                if { $event2Sub & $clkmgr::EventGMChanged } {
+                    puts [format $hd3b "gm_Changed"\
+                        [ $ptpClock isGmChanged ]\
+                        [ $ptpClock getGmChangedEventCount ]]
+                }
+            }
+            puts $hd3
+            set gmClockUUID [ $ptpClock getGmIdentity ]
+            # Copy the uint64_t into the array
+            for {set i 0} {$i < 8} {incr i} {
+                set id($i) [expr ($gmClockUUID >> (8 * (7 - $i))) & 0xff ]
+            }
+            puts [format "| %-26s|%s %02x%02x%02x.%02x%02x.%02x%02x%02x %s|"\
+                "GM UUID" "    "\
+                $id(0) $id(1) $id(2) $id(3)\
+                $id(4) $id(5) $id(6) $id(7) "    "]
+            puts [format "| %-25s |     %-19ld ns |" "clock_offset"\
+                [ $ptpClock getClockOffset ]]
+            puts [format "| %-25s |     %-19ld ns |" "notification_timestamp"\
+                [ $ptpClock getNotificationTimestamp ]]
+            puts [format "| %-25s |     %-19ld us |" "gm_sync_interval"\
+                [ $ptpClock getSyncInterval ]]
+            puts $hd3
+            if { $composite_event != 0 } {
+                puts [format $hd3b "composite_event"\
+                    [ $ptpClock isCompositeEventMet ]\
+                    [ $ptpClock getCompositeEventCount ]]
+                if { $composite_event & $clkmgr::EventGMOffset } {
+                    puts [format "| - %-23s | %-12s | %-11s |"\
+                        "offset_in_range" "" ""]
+                }
+                if { $composite_event & $clkmgr::EventSyncedToGM } {
+                    puts [format "| - %-19s | %-12s | %-11s |"\
+                        "synced_to_primary_clock" "" ""]
+                }
+                if { $composite_event & $clkmgr::EventASCapable } {
+                    puts [format "| - %-23s | %-12s | %-11s |"\
+                        "as_capable" "" ""]
+                }
+                puts $hd3
+            }
+            puts ""
+            puts $hd2l
+            puts [format $hd3b "chrony_offset_in_range"\
+                [ $sysClock isOffsetInRange ]\
+                [ $sysClock getOffsetInRangeEventCount ]]
+            puts $hd2l
+            puts [format "| %-25s |     %-19ld ns |"\
+                "chrony_clock_offset" [ $sysClock getClockOffset ]]
+            puts [format "| %-25s |     %-19lx    |"\
+                "chrony_clock_reference_id" [ $sysClock getGmIdentity ]]
+            puts [format "| %-25s |     %-19ld us |"\
+                "chrony_polling_interval" [ $sysClock getSyncInterval ]]
+            puts $hd2l
+            puts ""
+            puts [format "\[clkmgr]\[%.3f] sleep for %d seconds..."\
+                [expr [clock milliseconds ] / 1000.0 ] $idleTime ]
+            puts ""
+            if { $signal_flag } {
+                return 0
+            }
+            sleep $idleTime
+        }
+    }
+    return 0
+}
+main

--- a/wrappers/tcl/clkmgr_test.tcl
+++ b/wrappers/tcl/clkmgr_test.tcl
@@ -86,8 +86,9 @@ proc main {} {
         set help 1
     }
     if { [ info exist help ] || $params(h) } {
-    puts "
-Usage of $argv0:
+        set me [file tail $argv0]
+        puts "
+Usage of $me :
 Options:
   -a subscribe to all time base indices
      Default: timeBaseIndex: 1

--- a/wrappers/tcl/pkgIndex_tcl.sh
+++ b/wrappers/tcl/pkgIndex_tcl.sh
@@ -20,6 +20,7 @@ fi
 local -r ver="$ver_maj.$ver_min"
 cat << EOF > $file
 package ifneeded ptpmgmt $ver [list load [file join $PWD $1 ptpmgmt.so]]
+package ifneeded clkmgr $ver [list load [file join $PWD $1 clkmgr.so]]
 EOF
 }
 main "$@"


### PR DESCRIPTION
<h1>Suggested PR Title - Enhance type safety and documentation in clkmgr module, and update dependencies in Dockerfiles</h1>
Tested with C/C++ sample apps:
![image](https://github.com/user-attachments/assets/eec15168-2113-4ed1-845b-846646e36ab6)
<h1 style='color: red;'>${\color{red}DO \space NOT \space EDIT \space ANYTHING}$</h1>

### Smart DevOps AI Agent for GitHub: Release Version: v1.2-ww18-2025


>### Start of generated PR Summary by Smart DevOps Agent for GitHub

## Types of major changes in the pull request
code_enhancement, code_improvement


___

## Pull request change summary
- Refactored various functions across C++ and C interfaces in the clkmgr module to use enums for return types, enhancing type safety and readability.
- Updated sample applications and test scripts in multiple languages to align with the new enum types and improved error handling.
- Enhanced documentation and usage messages in test scripts and markdown files to provide clearer instructions.
- Modified Dockerfiles across different distributions to include the tclx package, ensuring compatibility and meeting new dependencies.


___

## High level Pull Request Summary
<table><thead><tr><th>Filename&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Summary of changes&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Link to file&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody>
<tr>
  <td><strong>clkmgr/client/clockmanager.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Refactored the statusWait and related functions to use enum <br>StatusWaitResult instead of int for return types, enhancing <br>type safety and readability.
 <br><br> Type of change: <br>Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-2f93f3abd0c220a988e8802733bbe861ccc4ccfba1c46130ce1b7ed68c950382"> +6/-3</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/client/clockmanager_c.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the C interface functions clkmgr_statusWaitByName <br>and clkmgr_statusWait to use enum Clkmgr_StatusWaitResult <br>instead of int, improving type safety and error handling.
 <br><br><br> Type of change: Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-e018f4d845fa1379731ded3811b94b54e8b40febad5eca6b4e75ca5227ccb6ad"> +9/-6</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/sample/clkmgr_test.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Enhanced the sample test application by using enum <br>StatusWaitResult for return types and improving the usage <br>message formatting.
 <br><br> Type of change: <br>Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-39d8863e2f42d4a016139a23a804368bc9d910f36a372ee321de5dd51f85697e"> +35/-22</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/pub/clockmanager.h</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Modified the ClockManager class methods to use enum <br>StatusWaitResult, aligning the C++ interface with the new <br>enum types for return values.
 <br><br> Type of change: <br>Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-bba6502ccf07abd754f126a37fb5d7002bd0651da0512069bba0a34fd2baac61"> +3/-2</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/sample/clkmgr_c_test.c</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the C sample test application to handle the new enum <br>return types from clock manager status wait functions, <br>improving error handling and output messages.
 <br><br> Type <br>of change: Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-f51b46df65bf7e722821f43e78e70047b5b6c576a73988348e400d49c96bfda5"> +34/-21</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/pub/clkmgr/clockmanager_c.h</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the header file to reflect the use of enum <br>Clkmgr_StatusWaitResult in function signatures for better <br>clarity and type safety.
 <br><br> Type of change: <br>Code_Documentation</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-5b3bee29102af0f848bf24d2b9909a1503e6ce6360c534103815bbfe80b32675"> +14/-6</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/TEST_clkmgr.md</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the markdown documentation for the clkmgr test, <br>refining the usage instructions and removing outdated <br>options.
 <br><br> Type of change: Code_Documentation</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-7840c1bf0f0c33faf4cd25d8ac090566386bc07e576091949f0869c47107e48f"> +3/-7</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/common/types.m4</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Changed the underlying type of StatusWaitResult enum from <br>int32_t to int8_t, optimizing memory usage.
 <br><br> Type <br>of change: Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-5bdb52786941d27ed8aeaa79e7b1acb31c97e8183152bcf7c25f142f16c193e7"> +1/-1</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/perl/clkmgr_test.pl</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the Perl wrapper test script to improve the usage <br>message and handle command line options more effectively.
 <br><br><br> Type of change: Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-3a2c533656da6ce40a239fd81d17b21c4313f3b8bd13281aa916024bd5064f6f"> +4/-2</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/python/clkmgr_test.py</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Enhanced the Python wrapper test script by refining the <br>usage message and adjusting command line option parsing.
 <br><br><br> Type of change: Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-c2fa5eb89c17a0fa21256311015f54296963450d754ba9c08a3b22454b643fe4"> +3/-3</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/php/clkmgr_test.php</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Improved the PHP wrapper test script by updating the usage <br>message and handling command line options more robustly.
 <br><br><br> Type of change: Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-d0e5724efe218dac081e598a234a92a8f1f5f025137ce247cc4719850d07460c"> +4/-3</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/ruby/clkmgr_test.rb</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the Ruby wrapper test script to enhance the usage <br>message and streamline command line option handling.
 <br><br><br> Type of change: Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-e18543c5165d398f09255820f6f92664e5afed37232ea04a5ce80a432d05f612"> +1/-3</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/utest/Makefile</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Refactored the Makefile for unit tests, improving clarity <br>and organization of object file dependencies.
 <br><br> Type <br>of change: Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-6dc248b1ea5cb71af12332ec7a87b4bca8df3851a06363601acfb663108651ff"> +33/-25</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/tcl/pkgIndex_tcl.sh</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added a package index entry for clkmgr in the Tcl wrapper, <br>facilitating the loading of the clkmgr.so shared library.
 <br><br><br> Type of change: Configuration_Changes</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-b4842005de2a546c0fbbb2bd4dadf51cff7d3eb620a2118678ee2cf9b34302be"> +1/-0</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/tcl/clkmgr_test.tcl</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Introduced a comprehensive Tcl test script for the Clock <br>Manager client, including detailed command handling and <br>output formatting.
 <br><br> Type of change: Create_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-156d703e74e1cd5de2070ecbe427bfd40e8423221bf17e40358b730663bf5944"> +428/-0</a></td>

</tr>                    

<tr>
  <td><strong>debian/Dockerfile</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added the tclx8.4 package to the Debian Dockerfile, ensuring <br>the availability of this dependency for building.
 <br><br> <br>Type of change: Dependencies</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-b98298742c5536fa90710aea60f865cdf0149b61c06288c4a0219ce4796ec807"> +1/-1</a></td>

</tr>                    

<tr>
  <td><strong>gentoo/Dockerfile.1</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Included the tclx package in the Gentoo Dockerfile to meet <br>new dependencies introduced by the Tcl wrapper.
 <br><br> <br>Type of change: Dependencies</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-f8031629a32e8e670fb1ea31aa213a97aa38742ca80a5773ad54614954f4499e"> +1/-1</a></td>

</tr>                    

<tr>
  <td><strong>rpm/Dockerfile</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added the tclx package to the RPM Dockerfile to support the <br>Tcl wrapper's requirements.
 <br><br> Type of change: <br>Dependencies</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/243/files#diff-28680721b21a395f1041fc66be2bc83027e7cec3158f750f9e5b7482dc5a3efd"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

>### End of generated PR Summary by Smart DevOps Agent for GitHub