### PR TITLE
clkmgr: Refactor clock type parameters to use Clkmgr_ClockType enum

### DIFF
--- a/clkmgr/client/clock_event.cpp
+++ b/clkmgr/client/clock_event.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "pub/clkmgr/event.h"
+#include "pub/clkmgr/types_c.h"
 #include "client/clock_event_handler.hpp"
 #include "client/opaque_struct_c.hpp"
 #include "client/timebase_state.hpp"
@@ -143,14 +144,14 @@ extern "C" {
     }
 
     int64_t clkmgr_getClockOffset(const Clkmgr_ClockSyncData *data_c,
-        uint32_t clock_type)
+        enum Clkmgr_ClockType clock_type)
     {
         if(!data_c)
             return 0;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 return data_c->data->getPtp().getClockOffset();
-            case SysClock:
+            case Clkmgr_SysClock:
                 return data_c->data->getSysClock().getClockOffset();
             default:
                 return 0;
@@ -158,14 +159,14 @@ extern "C" {
     }
 
     bool clkmgr_isOffsetInRange(const Clkmgr_ClockSyncData *data_c,
-        uint32_t clock_type)
+        enum Clkmgr_ClockType clock_type)
     {
         if(!data_c)
             return false;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 return data_c->data->getPtp().isOffsetInRange();
-            case SysClock:
+            case Clkmgr_SysClock:
                 return data_c->data->getSysClock().isOffsetInRange();
             default:
                 return false;
@@ -173,14 +174,14 @@ extern "C" {
     }
 
     uint32_t clkmgr_getOffsetInRangeEventCount(const Clkmgr_ClockSyncData *data_c,
-        uint32_t clock_type)
+        enum Clkmgr_ClockType clock_type)
     {
         if(!data_c)
             return 0;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 return data_c->data->getPtp().getOffsetInRangeEventCount();
-            case SysClock:
+            case Clkmgr_SysClock:
                 return data_c->data->getSysClock().getOffsetInRangeEventCount();
             default:
                 return 0;
@@ -188,14 +189,14 @@ extern "C" {
     }
 
     int64_t clkmgr_getSyncInterval(const Clkmgr_ClockSyncData *data_c,
-        uint32_t clock_type)
+        enum Clkmgr_ClockType clock_type)
     {
         if(!data_c)
             return 0;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 return data_c->data->getPtp().getSyncInterval();
-            case SysClock:
+            case Clkmgr_SysClock:
                 return data_c->data->getSysClock().getSyncInterval();
             default:
                 return 0;
@@ -203,14 +204,14 @@ extern "C" {
     }
 
     uint64_t clkmgr_getGmIdentity(const Clkmgr_ClockSyncData *data_c,
-        uint32_t clock_type)
+        enum Clkmgr_ClockType clock_type)
     {
         if(!data_c)
             return 0;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 return data_c->data->getPtp().getGmIdentity();
-            case SysClock:
+            case Clkmgr_SysClock:
                 return data_c->data->getSysClock().getGmIdentity();
             default:
                 return 0;
@@ -218,14 +219,14 @@ extern "C" {
     }
 
     bool clkmgr_isGmChanged(const Clkmgr_ClockSyncData *data_c,
-        uint32_t clock_type)
+        enum Clkmgr_ClockType clock_type)
     {
         if(!data_c)
             return false;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 return data_c->data->getPtp().isGmChanged();
-            case SysClock:
+            case Clkmgr_SysClock:
                 return data_c->data->getSysClock().isGmChanged();
             default:
                 return false;
@@ -233,14 +234,14 @@ extern "C" {
     }
 
     uint32_t clkmgr_getGmChangedEventCount(const Clkmgr_ClockSyncData *data_c,
-        uint32_t clock_type)
+        enum Clkmgr_ClockType clock_type)
     {
         if(!data_c)
             return 0;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 return data_c->data->getPtp().getGmChangedEventCount();
-            case SysClock:
+            case Clkmgr_SysClock:
                 return data_c->data->getSysClock().getGmChangedEventCount();
             default:
                 return 0;
@@ -248,14 +249,14 @@ extern "C" {
     }
 
     uint64_t clkmgr_getNotificationTimestamp(const Clkmgr_ClockSyncData *data_c,
-        uint32_t clock_type)
+        enum Clkmgr_ClockType clock_type)
     {
         if(!data_c)
             return 0;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 return data_c->data->getPtp().getNotificationTimestamp();
-            case SysClock:
+            case Clkmgr_SysClock:
                 return data_c->data->getSysClock().getNotificationTimestamp();
             default:
                 return 0;

--- a/clkmgr/client/subscription.cpp
+++ b/clkmgr/client/subscription.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "pub/clkmgr/subscription.h"
+#include "pub/clkmgr/types_c.h"
 #include "client/opaque_struct_c.hpp"
 #include "common/print.hpp"
 
@@ -130,19 +131,19 @@ extern "C" {
         delete sub_c;
     }
 
-    bool clkmgr_setEventMask(Clkmgr_Subscription *sub_c, uint32_t clock_type,
-        uint32_t mask)
+    bool clkmgr_setEventMask(Clkmgr_Subscription *sub_c,
+        enum Clkmgr_ClockType clock_type, uint32_t mask)
     {
         if(!sub_c)
             return false;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 if(sub_c->ptp->setEventMask(mask)) {
                     sub_c->sub->setPtpSubscription(*sub_c->ptp);
                     return true;
                 }
                 return false;
-            case SysClock:
+            case Clkmgr_SysClock:
                 if(sub_c->sys->setEventMask(mask)) {
                     sub_c->sub->setSysSubscription(*sub_c->sys);
                     return true;
@@ -154,14 +155,14 @@ extern "C" {
     }
 
     uint32_t clkmgr_getEventMask(const Clkmgr_Subscription *sub_c,
-        uint32_t clock_type)
+        enum Clkmgr_ClockType clock_type)
     {
         if(!sub_c)
             return 0;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 return sub_c->sub->getPtpSubscription().getEventMask();
-            case SysClock:
+            case Clkmgr_SysClock:
                 return sub_c->sub->getSysSubscription().getEventMask();
             default:
                 return 0;
@@ -191,11 +192,11 @@ extern "C" {
         if(!sub_c)
             return false;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 sub_c->ptp->setClockOffsetThreshold(threshold);
                 sub_c->sub->setPtpSubscription(*sub_c->ptp);
                 return true;
-            case SysClock:
+            case Clkmgr_SysClock:
                 sub_c->sys->setClockOffsetThreshold(threshold);
                 sub_c->sub->setSysSubscription(*sub_c->sys);
                 return true;
@@ -205,29 +206,30 @@ extern "C" {
     }
 
     uint32_t clkmgr_getClockOffsetThreshold(const Clkmgr_Subscription
-        *sub_c, uint32_t clock_type)
+        *sub_c, enum Clkmgr_ClockType clock_type)
     {
         if(!sub_c)
             return 0;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 return sub_c->sub->getPtpSubscription().getClockOffsetThreshold();
-            case SysClock:
+            case Clkmgr_SysClock:
                 return sub_c->sub->getSysSubscription().getClockOffsetThreshold();
             default:
                 return 0;
         }
     }
 
-    bool clkmgr_enableSubscription(Clkmgr_Subscription *sub_c, uint32_t clock_type)
+    bool clkmgr_enableSubscription(Clkmgr_Subscription *sub_c,
+        enum Clkmgr_ClockType clock_type)
     {
         if(!sub_c)
             return false;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 sub_c->sub->enablePtpSubscription();
                 return true;
-            case SysClock:
+            case Clkmgr_SysClock:
                 sub_c->sub->enableSysSubscription();
                 return true;
             default:
@@ -235,15 +237,16 @@ extern "C" {
         }
     }
 
-    bool clkmgr_disableSubscription(Clkmgr_Subscription *sub_c, uint32_t clock_type)
+    bool clkmgr_disableSubscription(Clkmgr_Subscription *sub_c,
+        enum Clkmgr_ClockType clock_type)
     {
         if(!sub_c)
             return false;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 sub_c->sub->disablePtpSubscription();
                 return true;
-            case SysClock:
+            case Clkmgr_SysClock:
                 sub_c->sub->disableSysSubscription();
                 return true;
             default:
@@ -252,14 +255,14 @@ extern "C" {
     }
 
     bool clkmgr_isSubscriptionEnabled(const Clkmgr_Subscription *sub_c,
-        uint32_t clock_type)
+        enum Clkmgr_ClockType clock_type)
     {
         if(!sub_c)
             return false;
         switch(clock_type) {
-            case PTPClock:
+            case Clkmgr_PTPClock:
                 return sub_c->sub->isPTPSubscriptionEnable();
-            case SysClock:
+            case Clkmgr_SysClock:
                 return sub_c->sub->isSysSubscriptionEnable();
             default:
                 return false;

--- a/clkmgr/common/types.m4
+++ b/clkmgr/common/types.m4
@@ -60,7 +60,7 @@ cnst(uint32_t,PTP_COMPOSITE_EVENT_ALL,Nm(EventGMOffset) | \
 * Types of clock available for subscription.
 * @note The Nm(ClockLast) is reserved for future use.
 */
-enum Nm(ClockType) sz(`: uint32_t '){
+enum Nm(ClockType) sz(`: uint8_t '){
     Nm(PTPClock) = 1, /**< PTP Clock */
     Nm(SysClock) = 2, /**< System Clock */
     Nm(ClockLast) = 3 /**< Last Clock */

--- a/clkmgr/pub/clkmgr/event_c.h
+++ b/clkmgr/pub/clkmgr/event_c.h
@@ -56,7 +56,7 @@ bool clkmgr_haveSysData(const Clkmgr_ClockSyncData *data_c);
  *  as defined by enum Clkmgr_ClockType
  */
 int64_t clkmgr_getClockOffset(const Clkmgr_ClockSyncData *data_c,
-    uint32_t clock_type);
+    enum Clkmgr_ClockType clock_type);
 
 /**
  * Check if the clock offset is in-range
@@ -68,7 +68,7 @@ int64_t clkmgr_getClockOffset(const Clkmgr_ClockSyncData *data_c,
  *  as defined by enum Clkmgr_ClockType
  */
 bool clkmgr_isOffsetInRange(const Clkmgr_ClockSyncData *data_c,
-    uint32_t clock_type);
+    enum Clkmgr_ClockType clock_type);
 
 /**
  * Get the count of clock offset in-range event
@@ -82,7 +82,7 @@ bool clkmgr_isOffsetInRange(const Clkmgr_ClockSyncData *data_c,
  *  as defined by enum Clkmgr_ClockType
  */
 uint32_t clkmgr_getOffsetInRangeEventCount(const Clkmgr_ClockSyncData *data_c,
-    uint32_t clock_type);
+    enum Clkmgr_ClockType clock_type);
 
 /**
  * Get the synchronization interval in microsecond
@@ -97,7 +97,7 @@ uint32_t clkmgr_getOffsetInRangeEventCount(const Clkmgr_ClockSyncData *data_c,
  *  as defined by enum Clkmgr_ClockType
  */
 int64_t clkmgr_getSyncInterval(const Clkmgr_ClockSyncData *data_c,
-    uint32_t clock_type);
+    enum Clkmgr_ClockType clock_type);
 
 /**
  * Get the grandmaster clock identity
@@ -110,7 +110,7 @@ int64_t clkmgr_getSyncInterval(const Clkmgr_ClockSyncData *data_c,
  *  as defined by enum Clkmgr_ClockType
  */
 uint64_t clkmgr_getGmIdentity(const Clkmgr_ClockSyncData *data_c,
-    uint32_t clock_type);
+    enum Clkmgr_ClockType clock_type);
 
 /**
  * Check if the grandmaster has changed
@@ -123,7 +123,7 @@ uint64_t clkmgr_getGmIdentity(const Clkmgr_ClockSyncData *data_c,
  *  as defined by enum Clkmgr_ClockType
  */
 bool clkmgr_isGmChanged(const Clkmgr_ClockSyncData *data_c,
-    uint32_t clock_type);
+    enum Clkmgr_ClockType clock_type);
 
 /**
  * Get the count of grandmaster changed event
@@ -136,7 +136,7 @@ bool clkmgr_isGmChanged(const Clkmgr_ClockSyncData *data_c,
  *  as defined by enum Clkmgr_ClockType
  */
 uint32_t clkmgr_getGmChangedEventCount(const Clkmgr_ClockSyncData *data_c,
-    uint32_t clock_type);
+    enum Clkmgr_ClockType clock_type);
 
 /**
  * Get the notification timestamp in nanosecond
@@ -149,7 +149,7 @@ uint32_t clkmgr_getGmChangedEventCount(const Clkmgr_ClockSyncData *data_c,
  * as defined by enum Clkmgr_ClockType
  */
 uint64_t clkmgr_getNotificationTimestamp(const Clkmgr_ClockSyncData *data_c,
-    uint32_t clock_type);
+    enum Clkmgr_ClockType clock_type);
 
 /**
  * Check if the PTP clock is synchronized with a grandmaster

--- a/clkmgr/pub/clkmgr/subscription_c.h
+++ b/clkmgr/pub/clkmgr/subscription_c.h
@@ -43,8 +43,8 @@ void clkmgr_destroySubscriptionInstance(Clkmgr_Subscription *sub_c);
  * @note The event mask is a bitmask where each bit represents an event,
  * as defined by enum Clkmgr_EventIndex
  */
-bool clkmgr_setEventMask(Clkmgr_Subscription *sub_c, uint32_t clock_type,
-    uint32_t mask);
+bool clkmgr_setEventMask(Clkmgr_Subscription *sub_c,
+    enum Clkmgr_ClockType clock_type, uint32_t mask);
 
 /**
  * Get the value of the event mask
@@ -55,7 +55,7 @@ bool clkmgr_setEventMask(Clkmgr_Subscription *sub_c, uint32_t clock_type,
  * as defined by enum Clkmgr_ClockType
  */
 uint32_t clkmgr_getEventMask(const Clkmgr_Subscription *sub_c,
-    uint32_t clock_type);
+    enum Clkmgr_ClockType clock_type);
 
 /**
  * Set the PTP composite event mask.
@@ -87,7 +87,7 @@ uint32_t clkmgr_getPtpCompositeEventMask(const Clkmgr_Subscription *sub_c);
  * @note The threshold sets a symmetric range of clock offset
  */
 bool clkmgr_setClockOffsetThreshold(Clkmgr_Subscription *sub_c,
-    uint32_t clock_type, uint32_t threshold);
+    enum Clkmgr_ClockType clock_type, uint32_t threshold);
 
 /**
  * Get the threshold of specify clock offset
@@ -98,7 +98,7 @@ bool clkmgr_setClockOffsetThreshold(Clkmgr_Subscription *sub_c,
  * as defined by enum Clkmgr_ClockType
  */
 uint32_t clkmgr_getClockOffsetThreshold(const Clkmgr_Subscription *sub_c,
-    uint32_t clock_type);
+    enum Clkmgr_ClockType clock_type);
 
 /**
  * Enable the subscription of the specify clock.
@@ -109,7 +109,8 @@ uint32_t clkmgr_getClockOffsetThreshold(const Clkmgr_Subscription *sub_c,
  * @note The clock type is a bit that represents a type of clock,
  * as defined by enum Clkmgr_ClockType
  */
-bool clkmgr_enableSubscription(Clkmgr_Subscription *sub_c, uint32_t clock_type);
+bool clkmgr_enableSubscription(Clkmgr_Subscription *sub_c,
+    enum Clkmgr_ClockType clock_type);
 
 /**
  * Disable the subscription of the specify clock.
@@ -121,7 +122,7 @@ bool clkmgr_enableSubscription(Clkmgr_Subscription *sub_c, uint32_t clock_type);
  * as defined by enum Clkmgr_ClockType
  */
 bool clkmgr_disableSubscription(Clkmgr_Subscription *sub_c,
-    uint32_t clock_type);
+    enum Clkmgr_ClockType clock_type);
 
 /**
  * Check if the specify clock subscription is enabled
@@ -132,7 +133,7 @@ bool clkmgr_disableSubscription(Clkmgr_Subscription *sub_c,
  * as defined by enum Clkmgr_ClockType
  */
 bool clkmgr_isSubscriptionEnabled(const Clkmgr_Subscription *sub_c,
-    uint32_t clock_type);
+    enum Clkmgr_ClockType clock_type);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<h1>Suggested PR Title - Refactor Clkmgr Clock Type Parameters to Use Enum and Optimize Memory Usage</h1>
- Changed the underlying type of the ClockType enum to `uint8_t`.
- Updated function signatures to use `enum Clkmgr_ClockType` for clock type parameters.

Tested with C/C++ sample apps:
![image](https://github.com/user-attachments/assets/f8ed68c0-83ed-447f-a751-b5e155f89c7d)


<h1 style='color: red;'>${\color{red}DO \space NOT \space EDIT \space ANYTHING}$</h1>

### Smart DevOps AI Agent for GitHub: Release Version: v1.2-ww18-2025


>### Start of generated PR Summary by Smart DevOps Agent for GitHub

## Types of major changes in the pull request
code_enhancement, code_improvement


___

## Pull request change summary
- Included types_c.h in clock_event.cpp and subscription.cpp to access the Clkmgr_ClockType enum.
- Updated various function parameters across multiple files (clock_event.cpp, subscription.cpp, event_c.h, subscription_c.h) from uint32_t to enum Clkmgr_ClockType to enhance type safety and readability.
- Changed the underlying type of the Clkmgr_ClockType enum from uint32_t to uint8_t in types.m4 to optimize memory usage.


___

## High level Pull Request Summary
<table><thead><tr><th>Filename&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Summary of changes&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Link to file&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody>
<tr>
  <td><strong>clkmgr/client/clock_event.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>- Included the header types_c.h which defines the <br>Clkmgr_ClockType enum.
- Updated function parameters from <br>uint32_t to enum Clkmgr_ClockType for clock type parameters <br>in various functions to enhance type safety and <br>readability.
 <br><br> Type of change: Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/244/files#diff-1f8b9b30a2e6c98dcca85e4f5e1a5755811c37de68043b49fe9d76e09860f276"> +9/-8</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/client/subscription.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>- Included the header types_c.h which defines the <br>Clkmgr_ClockType enum.
- Updated function parameters from <br>uint32_t to enum Clkmgr_ClockType for clock type parameters <br>in various functions to enhance type safety and <br>readability.
 <br><br> Type of change: Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/244/files#diff-5ba4480db6ba3b4b6758d4d4ab6adc9a0756f041d9b7a129191362c2fb67b530"> +10/-7</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/pub/clkmgr/event_c.h</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>- Updated function parameters from uint32_t to enum <br>Clkmgr_ClockType for clock type parameters in various <br>functions to enhance type safety and readability.
 <br><br> <br>Type of change: Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/244/files#diff-2434e14b23878d3e02f44cb096b1a4ae9fa91ee24ef0e8c2dc9bac3daddf02b8"> +8/-8</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/pub/clkmgr/subscription_c.h</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>- Updated function parameters from uint32_t to enum <br>Clkmgr_ClockType for clock type parameters in various <br>functions to enhance type safety and readability.
 <br><br> <br>Type of change: Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/244/files#diff-a0120c63059ab8c869e311d3edde9ea01cdebc90ada7ee522b338b83087e7005"> +9/-8</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/common/types.m4</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>- Changed the underlying type of the Clkmgr_ClockType enum <br>from uint32_t to uint8_t to reduce memory usage.
 <br><br> <br>Type of change: Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/244/files#diff-5bdb52786941d27ed8aeaa79e7b1acb31c97e8183152bcf7c25f142f16c193e7"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

>### End of generated PR Summary by Smart DevOps Agent for GitHub