### PR TITLE
clkmgr: Refactor syncInterval type to uint64_t

### DIFF
--- a/clkmgr/client/clock_event.cpp
+++ b/clkmgr/client/clock_event.cpp
@@ -54,7 +54,7 @@ bool ClockEventBase::isGmChanged() const
     return gmChanged;
 }
 
-int64_t ClockEventBase::getSyncInterval() const
+uint64_t ClockEventBase::getSyncInterval() const
 {
     return syncInterval;
 }
@@ -200,7 +200,7 @@ extern "C" {
         }
     }
 
-    int64_t clkmgr_getSyncInterval(const Clkmgr_ClockSyncData *data_c,
+    uint64_t clkmgr_getSyncInterval(const Clkmgr_ClockSyncData *data_c,
         enum Clkmgr_ClockType clock_type)
     {
         if(!data_c)

--- a/clkmgr/common/types.m4
+++ b/clkmgr/common/types.m4
@@ -58,12 +58,10 @@ cnst(uint32_t,PTP_COMPOSITE_EVENT_ALL,Nm(EventGMOffset) | \
 
 /**
 * Types of clock available for subscription.
-* @note The Nm(ClockLast) is reserved for future use.
 */
 enum Nm(ClockType) sz(`: uint8_t '){
     Nm(PTPClock) = 1, /**< PTP Clock */
     Nm(SysClock) = 2, /**< System Clock */
-    Nm(ClockLast) = 3 /**< Last Clock */
 };
 
 /**

--- a/clkmgr/pub/clkmgr/event.h
+++ b/clkmgr/pub/clkmgr/event.h
@@ -76,7 +76,7 @@ class ClockEventBase
      *  time the synchronization protocol may need to react for a change in the
      *  grandmaster.
      */
-    int64_t getSyncInterval() const;
+    uint64_t getSyncInterval() const;
 
     /**
      * Get the grandmaster clock identity
@@ -125,7 +125,7 @@ class ClockEventBase
     ClockEventBase() = default; /**< Constructs a ClockEventBase object. */
     friend class ClockEventHandler; /**< Grants access to ClockEventHandler. */
     int64_t clockOffset = 0; /**< Offset of the clock in nanoseconds. */
-    int64_t syncInterval = 0; /**< Synchronization interval in nanoseconds. */
+    uint64_t syncInterval = 0; /**< Synchronization interval in nanoseconds. */
     uint64_t gmClockUUID = 0; /**< UUID of the grandmaster clock. */
     /** Timestamp of last notification event. */
     uint64_t notificationTimestamp = 0;

--- a/clkmgr/pub/clkmgr/event_c.h
+++ b/clkmgr/pub/clkmgr/event_c.h
@@ -96,7 +96,7 @@ uint32_t clkmgr_getOffsetInRangeEventCount(const Clkmgr_ClockSyncData *data_c,
  * @note The clock type is a bit that represents a type of clock,
  *  as defined by enum Clkmgr_ClockType
  */
-int64_t clkmgr_getSyncInterval(const Clkmgr_ClockSyncData *data_c,
+uint64_t clkmgr_getSyncInterval(const Clkmgr_ClockSyncData *data_c,
     enum Clkmgr_ClockType clock_type);
 
 /**

--- a/clkmgr/pub/clkmgr/timebase_configs.h
+++ b/clkmgr/pub/clkmgr/timebase_configs.h
@@ -2,7 +2,7 @@
    SPDX-FileCopyrightText: Copyright © 2025 Intel Corporation. */
 
 /** @file
- * @brief Get and set the configuration of time base
+ * @brief Get the configuration of time base
  *
  * @author Song Yoong Siang <yoong.siang.song@@intel.com>
  * @copyright © 2025 Intel Corporation.

--- a/clkmgr/pub/clkmgr/timebase_configs_c.h
+++ b/clkmgr/pub/clkmgr/timebase_configs_c.h
@@ -2,7 +2,7 @@
    SPDX-FileCopyrightText: Copyright © 2025 Intel Corporation. */
 
 /** @file
- * @brief C wrapper to get and set the configuration of time base
+ * @brief C wrapper to get the configuration of time base
  *
  * @author Song Yoong Siang <yoong.siang.song@@intel.com>
  * @copyright © 2025 Intel Corporation.


### PR DESCRIPTION
<h1>Suggested PR Title - Refactor syncInterval to uint64_t and Remove Unused Enum Entry</h1>
- Changed the type of syncInterval to ensure synchronization intervals are represented as non-negative values.
- Removed the unused Nm(ClockLast) entry from the ClockType enum

Tested with C/C++ sample application:
![image](https://github.com/user-attachments/assets/2b33aa96-15f7-48cb-9444-2d57a62d754a)

<h1 style='color: red;'>${\color{red}DO \space NOT \space EDIT \space ANYTHING}$</h1>

### Smart DevOps AI Agent for GitHub: Release Version: v1.2-ww18-2025


>### Start of generated PR Summary by Smart DevOps Agent for GitHub

## Types of major changes in the pull request
code_enhancement


___

## Pull request change summary
- Changed the return type of getSyncInterval() from int64_t to uint64_t in multiple files to ensure synchronization intervals are represented as non-negative values.
- Removed the unused Nm(ClockLast) entry from the ClockType enum in event.h and types.m4.
- Updated documentation in timebase_configs.h and timebase_configs_c.h to accurately reflect the functionality of getting time base configurations.


___

## High level Pull Request Summary
<table><thead><tr><th>Filename&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Summary of changes&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Link to file&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody>
<tr>
  <td><strong>clkmgr/client/clock_event.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Changed the return type of getSyncInterval() from int64_t to <br>uint64_t to ensure synchronization intervals are represented <br>as non-negative values.
 <br><br> Type of change: Code <br>Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/245/files#diff-1f8b9b30a2e6c98dcca85e4f5e1a5755811c37de68043b49fe9d76e09860f276"> +2/-2</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/pub/clkmgr/event.h</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the getSyncInterval() method's return type from <br>int64_t to uint64_t and removed the unused Nm(ClockLast) <br>entry from the ClockType enum.
 <br><br> Type of change: <br>Code Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/245/files#diff-feb441c02acc85ffa6a570a44e1c771b7699fab74756c38b1e37afb682d0e579"> +2/-2</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/pub/clkmgr/event_c.h</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Modified the clkmgr_getSyncInterval() function to return <br>uint64_t instead of int64_t.
 <br><br> Type of change: Code <br>Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/245/files#diff-2434e14b23878d3e02f44cb096b1a4ae9fa91ee24ef0e8c2dc9bac3daddf02b8"> +1/-1</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/common/types.m4</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Removed the unused Nm(ClockLast) entry from the ClockType <br>enum, simplifying the enum definitions.
 <br><br> Type of <br>change: Code Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/245/files#diff-5bdb52786941d27ed8aeaa79e7b1acb31c97e8183152bcf7c25f142f16c193e7"> +0/-2</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/pub/clkmgr/timebase_configs.h</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the file documentation to reflect only getting <br>configurations, removing mentions of setting <br>configurations.
 <br><br> Type of change: Code Documentation</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/245/files#diff-00e376ca93ec51f3a84cc0dfa543b719fe3f4ed2246811c158abf8ae62627460"> +1/-1</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/pub/clkmgr/timebase_configs_c.h</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the C wrapper documentation to align with changes in <br>timebase_configs.h, focusing on getting configurations.
 <br><br><br> Type of change: Code Documentation</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/245/files#diff-b059ad7f7ea14d60fde5613f7181d58b92e044895a4c8c8a764087f0a39b283e"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

>### End of generated PR Summary by Smart DevOps Agent for GitHub