### PR TITLE
Update event mask enum and remove @brief for doxygen

### DIFF
--- a/.github/workflows/build_gentoo2.yml
+++ b/.github/workflows/build_gentoo2.yml
@@ -23,6 +23,7 @@ env:
 jobs:
   gentoo:
     runs-on: ubuntu-24.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     # Sets permissions of the GITHUB_TOKEN to allow upload new container
     permissions:
       contents: read

--- a/archlinux/Dockerfile
+++ b/archlinux/Dockerfile
@@ -19,7 +19,8 @@ RUN pacman-key --init && pacman-key --populate &&\
     lua lua51 lua52 lua53 vim tcl json-c php m4 gtest texlive-core go jq\
     texlive-fontutils astyle lua-posix lua51-posix lua52-posix lua53-posix\
     clang openssl gnutls nettle gdb debugedit base-devel chrpath patchelf\
-    discount ruby-test-unit cppcheck criterion chrony quilt cmark-gfm &&\
+    discount ruby-test-unit cppcheck criterion chrony quilt cmark-gfm\
+    systemd-libs &&\
     useradd $USER -u $UID -m -G users,wheel &&\
     echo "$USER ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers &&\
     mkdir -p /t0 && cd /t0 && git clone https://github.com/linux-rt/librtpi &&\

--- a/clkmgr/TEST_clkmgr.md
+++ b/clkmgr/TEST_clkmgr.md
@@ -228,15 +228,15 @@ Options:
   -p enable user to subscribe to specific time base indices  
   -s subscribe_event_mask  
      Default: 0xf  
-     Bit 0: EventGMOffset  
-     Bit 1: EventSyncedToGM  
-     Bit 2: EventASCapable  
-     Bit 3: EventGMChanged  
+     Bit 0: EventOffsetInRange  
+     Bit 1: EventSyncedWithGm  
+     Bit 2: EventAsCapable  
+     Bit 3: EventGmChanged  
   -c composite_event_mask  
      Default: 0x7  
-     Bit 0: EventGMOffset  
-     Bit 1: EventSyncedToGM  
-     Bit 2: EventASCapable  
+     Bit 0: EventOffsetInRange  
+     Bit 1: EventSyncedWithGm  
+     Bit 2: EventAsCapable  
   -l gm offset threshold (ns)  
      Default: 100000 ns  
   -i idle time (s)  

--- a/clkmgr/client/client_state.hpp
+++ b/clkmgr/client/client_state.hpp
@@ -27,9 +27,9 @@ class Message;
 class ClientState
 {
   private:
-    static std::string m_clientID; /**< Client ID */
+    static std::string m_clientID;
     static std::atomic<sessionId_t> m_sessionId;
-    static std::atomic_bool m_connected; /**< Connection status */
+    static std::atomic_bool m_connected;
 
   public:
     static bool init();

--- a/clkmgr/client/connect_msg.cpp
+++ b/clkmgr/client/connect_msg.cpp
@@ -21,7 +21,7 @@ __CLKMGR_NAMESPACE_USE;
 using namespace std;
 
 /**
- * @brief process the reply for connect msg from proxy.
+ * Process the reply for connect msg from proxy.
  *
  * This function will be called when the transport layer
  * in client runtime received a CONNECT_MSG type (an echo reply from

--- a/clkmgr/client/subscribe_msg.cpp
+++ b/clkmgr/client/subscribe_msg.cpp
@@ -20,7 +20,7 @@ __CLKMGR_NAMESPACE_USE;
 using namespace std;
 
 /**
- * @brief process the reply for notification msg from proxy.
+ * Process the reply for notification msg from proxy.
  *
  * This function will be called when the transport layer
  * in client runtime received a SUBSCRIBE_MSG type (an echo reply from

--- a/clkmgr/client/timebase_state.cpp
+++ b/clkmgr/client/timebase_state.cpp
@@ -153,8 +153,8 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
     // Get the current state of the timebase
     PTPClockEvent ptp4lEventState = state.get_ptp4lEventState();
     SysClockEvent chronyEventState = state.get_chronyEventState();
-    // Update EventGMOffset
-    if((ptpEventSub & EventGMOffset) &&
+    // Update EventOffsetInRange
+    if((ptpEventSub & EventOffsetInRange) &&
         (newEvent.master_offset != ptp4lEventState.getClockOffset())) {
         ptpClockEventHandler.setClockOffset(ptp4lEventState,
             newEvent.master_offset);
@@ -176,8 +176,8 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
             }
         }
     }
-    // Update EventSyncedToGM
-    if((ptpEventSub & EventSyncedToGM) &&
+    // Update EventSyncedWithGm
+    if((ptpEventSub & EventSyncedWithGm) &&
         (newEvent.synced_to_primary_clock !=
             ptp4lEventState.isSyncedWithGm())) {
         ptpClockEventHandler.setSyncedWithGm(ptp4lEventState,
@@ -186,14 +186,14 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
             ptp4lEventState.getSyncedWithGmEventCount() + 1);
         state.set_event_changed(true);
     }
-    // Update EventGMChanged
+    // Update EventGmChanged
     uint64_t sourceClockUUID = ptp4lEventState.getGmIdentity();
     uint8_t sourceClockUUIDBytes[8];
     for(int i = 0; i < 8; ++i) {
         sourceClockUUIDBytes[i] =
             static_cast<uint8_t>(sourceClockUUID >>(8 * (7 - i)));
     }
-    if((ptpEventSub & EventGMChanged) &&
+    if((ptpEventSub & EventGmChanged) &&
         (memcmp(sourceClockUUIDBytes, newEvent.gm_identity,
                 sizeof(newEvent.gm_identity)) != 0)) {
         uint64_t identity = 0;
@@ -207,8 +207,8 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
             ptp4lEventState.getGmChangedEventCount() + 1);
         state.set_event_changed(true);
     }
-    // Update EventASCapable
-    if((ptpEventSub & EventASCapable) &&
+    // Update EventAsCapable
+    if((ptpEventSub & EventAsCapable) &&
         (newEvent.as_capable != ptp4lEventState.isAsCapable())) {
         ptpClockEventHandler.setAsCapable(ptp4lEventState, newEvent.as_capable);
         ptpClockEventHandler.setAsCapableEventCount(ptp4lEventState,
@@ -217,11 +217,11 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
     }
     // Update composite event
     bool composite_event = true;
-    if(ptpCompositeEventSub & EventGMOffset)
+    if(ptpCompositeEventSub & EventOffsetInRange)
         composite_event &= ptp4lEventState.isOffsetInRange();
-    if(ptpCompositeEventSub & EventSyncedToGM)
+    if(ptpCompositeEventSub & EventSyncedWithGm)
         composite_event &= ptp4lEventState.isSyncedWithGm();
-    if(ptpCompositeEventSub & EventASCapable)
+    if(ptpCompositeEventSub & EventAsCapable)
         composite_event &= ptp4lEventState.isAsCapable();
     if(ptpCompositeEventSub &&
         (composite_event != ptp4lEventState.isCompositeEventMet())) {
@@ -241,7 +241,7 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
     ptpClockEventHandler.setSyncInterval(ptp4lEventState,
         newEvent.ptp4l_sync_interval);
     // Update Chrony clock offset
-    if((sysEventSub & EventGMOffset) &&
+    if((sysEventSub & EventOffsetInRange) &&
         (newEvent.chrony_offset != chronyEventState.getClockOffset())) {
         sysClockEventHandler.setClockOffset(chronyEventState,
             newEvent.chrony_offset);

--- a/clkmgr/common/types.m4
+++ b/clkmgr/common/types.m4
@@ -30,31 +30,33 @@ ns_s()
  * Bitmask of events available for subscription. Each bit represents one event.
  */
 enum Nm(EventIndex) sz(`: uint32_t '){
-    /** Offset between primary and secondary clock */
-    Nm(EventGMOffset) = 1 << 0,
-    /** Secondary clock is synced to primary clock */
-    Nm(EventSyncedToGM) = 1 << 1,
-    Nm(EventASCapable) = 1 << 2, /**< Link Partner is IEEE 802.1AS capable */
-    Nm(EventGMChanged) = 1 << 3, /**< UUID of primary clock is changed */
+    /** Event indicating whether clock offset is in-range */
+    Nm(EventOffsetInRange) = 1 << 0,
+    /** Event indicating whether PTP clock is synchronized with a grandmaster */
+    Nm(EventSyncedWithGm) = 1 << 1,
+    /** Event indicating whether clock is an IEEE 802.1AS capable */
+    Nm(EventAsCapable) = 1 << 2,
+    /** Event indicating whether grandmaster has changed */
+    Nm(EventGmChanged) = 1 << 3,
 };
 
 /**
  * All the PTP clock events available for subscription.
  */
-cnst(uint32_t,PTP_EVENT_ALL,Nm(EventGMOffset) | \
-    Nm(EventSyncedToGM) | Nm(EventASCapable) | Nm(EventGMChanged))
+cnst(uint32_t,PTP_EVENT_ALL,Nm(EventOffsetInRange) | \
+    Nm(EventSyncedWithGm) | Nm(EventAsCapable) | Nm(EventGmChanged))
 
 /**
  * All the System clock events available for subscription.
  */
-cnst(uint32_t,SYS_EVENT_ALL,Nm(EventGMOffset))
+cnst(uint32_t,SYS_EVENT_ALL,Nm(EventOffsetInRange))
 
 /**
  * All the events that can be used as conditions for satisfying the composite
  * event of PTP clock.
  */
-cnst(uint32_t,PTP_COMPOSITE_EVENT_ALL,Nm(EventGMOffset) | \
-    Nm(EventSyncedToGM) | Nm(EventASCapable))
+cnst(uint32_t,PTP_COMPOSITE_EVENT_ALL,Nm(EventOffsetInRange) | \
+    Nm(EventSyncedWithGm) | Nm(EventAsCapable))
 
 /**
 * Types of clock available for subscription.

--- a/clkmgr/proxy/connect_msg.cpp
+++ b/clkmgr/proxy/connect_msg.cpp
@@ -21,7 +21,7 @@ __CLKMGR_NAMESPACE_USE;
 using namespace std;
 
 /**
- * @brief process the connect msg from client-runtime
+ * Process the connect msg from client-runtime
  *
  * This function will be called when the transport layer
  * in proxy receive a CONNECT_MSG type from client-runtime.

--- a/clkmgr/proxy/connect_ptp4l.cpp
+++ b/clkmgr/proxy/connect_ptp4l.cpp
@@ -84,7 +84,7 @@ class ptpSet : public Thread4TimeBase, MessageDispatcher
         return msg_send();
     }
     /**
-     * @brief Subscribes to a set of PTP (Precision Time Protocol) events.
+     * Subscribes to a set of PTP (Precision Time Protocol) events.
      *
      * This function configures a subscription to various PTP events
      * by setting the appropriate bitmask in a subscription data
@@ -187,7 +187,7 @@ void ptpSet::event_handle()
 }
 
 /**
- * @brief Runs the main event loop for handling PTP (Precision Time Protocol)
+ * Runs the main event loop for handling PTP (Precision Time Protocol)
  *        events.
  *
  * This function enters an infinite loop, where it sends a GET request
@@ -290,7 +290,7 @@ class Ptp4l : public ConnectSrv
 static Ptp4l instance;
 
 /**
- * @brief Establishes a connection to the local PTP (Precision Time Protocol)
+ * Establishes a connection to the local PTP (Precision Time Protocol)
  *        daemon.
  *
  * This method initializes a Unix socket connection to the local PTP daemon.

--- a/clkmgr/sample/clkmgr_c_test.c
+++ b/clkmgr/sample/clkmgr_c_test.c
@@ -36,11 +36,11 @@ void signal_handler(int sig)
 
 static struct timespec ts;
 
-static uint32_t eventMask = Clkmgr_EventGMOffset | Clkmgr_EventSyncedToGM |
-    Clkmgr_EventASCapable | Clkmgr_EventGMChanged;
-static uint32_t compositeEventMask = Clkmgr_EventGMOffset |
-    Clkmgr_EventSyncedToGM | Clkmgr_EventASCapable;
-static uint32_t chronyEventMask = Clkmgr_EventGMOffset;
+static uint32_t eventMask = Clkmgr_EventOffsetInRange | Clkmgr_EventSyncedWithGm |
+    Clkmgr_EventAsCapable | Clkmgr_EventGmChanged;
+static uint32_t compositeEventMask = Clkmgr_EventOffsetInRange |
+    Clkmgr_EventSyncedWithGm | Clkmgr_EventAsCapable;
+static uint32_t chronyEventMask = Clkmgr_EventOffsetInRange;
 
 static double getMonotonicTime() {
     struct timespec time_spec;
@@ -94,34 +94,34 @@ static void printOut(Clkmgr_ClockSyncData *syncData)
             clkmgr_isPtpCompositeEventMet(syncData),
             clkmgr_getPtpCompositeEventCount(syncData));
     }
-    if (compositeEventMask & Clkmgr_EventGMOffset) {
+    if (compositeEventMask & Clkmgr_EventOffsetInRange) {
         printf("| - %-26s | %-12s | %-11s |\n", "isOffsetInRange", "", "");
     }
-    if (compositeEventMask & Clkmgr_EventSyncedToGM) {
+    if (compositeEventMask & Clkmgr_EventSyncedWithGm) {
         printf("| - %-26s | %-12s | %-11s |\n", "isSyncedWithGm", "", "");
     }
-    if (compositeEventMask & Clkmgr_EventASCapable) {
+    if (compositeEventMask & Clkmgr_EventAsCapable) {
         printf("| - %-26s | %-12s | %-11s |\n", "isAsCapable", "", "");
     }
     if (eventMask) {
     printf("|------------------------------|--------------|-------------|\n");
     }
-    if (eventMask & Clkmgr_EventGMOffset) {
+    if (eventMask & Clkmgr_EventOffsetInRange) {
         printf("| %-28s | %-12d | %-11d |\n", "ptp_isOffsetInRange",
             clkmgr_isOffsetInRange(syncData, Clkmgr_PTPClock),
             clkmgr_getOffsetInRangeEventCount(syncData, Clkmgr_PTPClock));
     }
-    if (eventMask & Clkmgr_EventSyncedToGM) {
+    if (eventMask & Clkmgr_EventSyncedWithGm) {
         printf("| %-28s | %-12d | %-11d |\n", "ptp_isSyncedWithGm",
             clkmgr_isPtpSyncedWithGm(syncData),
             clkmgr_getPtpSyncedWithGmEventCount(syncData));
     }
-    if (eventMask & Clkmgr_EventASCapable) {
+    if (eventMask & Clkmgr_EventAsCapable) {
         printf("| %-28s | %-12d | %-11d |\n", "ptp_isAsCapable",
             clkmgr_isPtpAsCapable(syncData),
             clkmgr_getPtpAsCapableEventCount(syncData));
     }
-    if (eventMask & Clkmgr_EventGMChanged) {
+    if (eventMask & Clkmgr_EventGmChanged) {
         printf("| %-28s | %-12d | %-11d |\n", "ptp_isGmChanged",
             clkmgr_isGmChanged(syncData, Clkmgr_PTPClock),
             clkmgr_getGmChangedEventCount(syncData, Clkmgr_PTPClock));
@@ -233,18 +233,18 @@ int main(int argc, char *argv[])
                    "  -p enable user to subscribe to specific time base indices\n"
                    "  -s subscribe_event_mask\n"
                    "     Default: 0x%x\n"
-                   "     Bit 0: EventGMOffset\n"
-                   "     Bit 1: EventSyncedToGM\n"
-                   "     Bit 2: EventASCapable\n"
-                   "     Bit 3: EventGMChanged\n"
+                   "     Bit 0: EventOffsetInRange\n"
+                   "     Bit 1: EventSyncedWithGm\n"
+                   "     Bit 2: EventAsCapable\n"
+                   "     Bit 3: EventGmChanged\n"
                    "  -c composite_event_mask\n"
                    "     Default: 0x%x\n"
-                   "     Bit 0: EventGMOffset\n"
-                   "     Bit 1: EventSyncedToGM\n"
-                   "     Bit 2: EventASCapable\n"
+                   "     Bit 0: EventOffsetInRange\n"
+                   "     Bit 1: EventSyncedWithGm\n"
+                   "     Bit 2: EventAsCapable\n"
                    "  -n chrony_event_mask\n"
                    "     Default: 0x%x\n"
-                   "     Bit 0: EventGMOffset\n"
+                   "     Bit 0: EventOffsetInRange\n"
                    "  -l gm offset threshold (ns)\n"
                    "     Default: %d ns\n"
                    "  -i idle time (s)\n"
@@ -266,18 +266,18 @@ int main(int argc, char *argv[])
                    "  -p enable user to subscribe to specific time base indices\n"
                    "  -s subscribe_event_mask\n"
                    "     Default: 0x%x\n"
-                   "     Bit 0: EventGMOffset\n"
-                   "     Bit 1: EventSyncedToGM\n"
-                   "     Bit 2: EventASCapable\n"
-                   "     Bit 3: EventGMChanged\n"
+                   "     Bit 0: EventOffsetInRange\n"
+                   "     Bit 1: EventSyncedWithGm\n"
+                   "     Bit 2: EventAsCapable\n"
+                   "     Bit 3: EventGmChanged\n"
                    "  -c composite_event_mask\n"
                    "     Default: 0x%x\n"
-                   "     Bit 0: EventGMOffset\n"
-                   "     Bit 1: EventSyncedToGM\n"
-                   "     Bit 2: EventASCapable\n"
+                   "     Bit 0: EventOffsetInRange\n"
+                   "     Bit 1: EventSyncedWithGm\n"
+                   "     Bit 2: EventAsCapable\n"
                    "  -n chrony_event_mask\n"
                    "     Default: 0x%x\n"
-                   "     Bit 0: EventGMOffset\n"
+                   "     Bit 0: EventOffsetInRange\n"
                    "  -l gm offset threshold (ns)\n"
                    "     Default: %d ns\n"
                    "  -i idle time (s)\n"

--- a/clkmgr/sample/clkmgr_test.cpp
+++ b/clkmgr/sample/clkmgr_test.cpp
@@ -35,12 +35,12 @@ static PTPClockEvent &ptpClock = clockSyncData.getPtp();
 static SysClockEvent &sysClock = clockSyncData.getSysClock();
 
 static uint32_t event2Sub =
-    EventGMOffset | EventSyncedToGM | EventASCapable | EventGMChanged;
+    EventOffsetInRange | EventSyncedWithGm | EventAsCapable | EventGmChanged;
 
 static uint32_t composite_event =
-    EventGMOffset | EventSyncedToGM | EventASCapable;
+    EventOffsetInRange | EventSyncedWithGm | EventAsCapable;
 
-static uint32_t chronyEvent = EventGMOffset;
+static uint32_t chronyEvent = EventOffsetInRange;
 
 static uint64_t gmClockUUID;
 static timespec ts;
@@ -99,32 +99,32 @@ static void printOut()
         printf("| %-28s | %-12d | %-11d |\n", "ptp_isCompositeEventMet",
             ptpClock.isCompositeEventMet(), ptpClock.getCompositeEventCount());
     }
-    if (composite_event & EventGMOffset) {
+    if (composite_event & EventOffsetInRange) {
         printf("| - %-26s | %-12s | %-11s |\n", "isOffsetInRange", "", "");
     }
-    if (composite_event & EventSyncedToGM) {
+    if (composite_event & EventSyncedWithGm) {
         printf("| - %-26s | %-12s | %-11s |\n", "isSyncedWithGm", "", "");
     }
-    if (composite_event & EventASCapable) {
+    if (composite_event & EventAsCapable) {
         printf("| - %-26s | %-12s | %-11s |\n", "isAsCapable", "", "");
     }
     if (event2Sub) {
         printf("|------------------------------|--------------|-------------|\n");
     }
-    if (event2Sub & EventGMOffset) {
+    if (event2Sub & EventOffsetInRange) {
         printf("| %-28s | %-12d | %-11d |\n", "ptp_isOffsetInRange",
             ptpClock.isOffsetInRange(),
             ptpClock.getOffsetInRangeEventCount());
     }
-    if (event2Sub & EventSyncedToGM) {
+    if (event2Sub & EventSyncedWithGm) {
         printf("| %-28s | %-12d | %-11d |\n", "ptp_isSyncedWithGm",
             ptpClock.isSyncedWithGm(), ptpClock.getSyncedWithGmEventCount());
     }
-    if (event2Sub & EventASCapable) {
+    if (event2Sub & EventAsCapable) {
         printf("| %-28s | %-12d | %-11d |\n", "ptp_isAsCapable",
             ptpClock.isAsCapable(), ptpClock.getAsCapableEventCount());
     }
-    if (event2Sub & EventGMChanged) {
+    if (event2Sub & EventGmChanged) {
         printf("| %-28s | %-12d | %-11d |\n", "ptp_isGmChanged",
             ptpClock.isGmChanged(), ptpClock.getGmChangedEventCount());
     }
@@ -240,15 +240,15 @@ int main(int argc, char *argv[])
                 "  -p enable user to subscribe to specific time base indices" << std::endl <<
                 "  -s subscribe_event_mask" << std::endl <<
                 "     Default: 0x" << std::hex << event2Sub << std::endl <<
-                "     Bit 0: EventGMOffset" << std::endl <<
-                "     Bit 1: EventSyncedToGM" << std::endl <<
-                "     Bit 2: EventASCapable" << std::endl <<
-                "     Bit 3: EventGMChanged" << std::endl <<
+                "     Bit 0: EventOffsetInRange" << std::endl <<
+                "     Bit 1: EventSyncedWithGm" << std::endl <<
+                "     Bit 2: EventAsCapable" << std::endl <<
+                "     Bit 3: EventGmChanged" << std::endl <<
                 "  -c composite_event_mask" << std::endl <<
                 "     Default: 0x" << composite_event << std::endl <<
-                "     Bit 0: EventGMOffset" << std::endl <<
-                "     Bit 1: EventSyncedToGM" << std::endl <<
-                "     Bit 2: EventASCapable" << std::endl <<
+                "     Bit 0: EventOffsetInRange" << std::endl <<
+                "     Bit 1: EventSyncedWithGm" << std::endl <<
+                "     Bit 2: EventAsCapable" << std::endl <<
                 "  -l gm offset threshold (ns)" << std::endl <<
                 "     Default: " << std::dec << ptp4lClockOffsetThreshold << " ns" << std::endl <<
                 "  -i idle time (s)" << std::endl <<
@@ -257,7 +257,7 @@ int main(int argc, char *argv[])
                 "     Default: " << chronyClockOffsetThreshold << " ns" << std::endl <<
                 "  -n chrony_event_mask" << std::endl <<
                 "     Default: 0x" << std::hex << chronyEvent << std::endl <<
-                "     Bit 0: EventGMOffset" << std::endl <<
+                "     Bit 0: EventOffsetInRange" << std::endl <<
                 "  -t timeout in waiting notification event (s)" << std::endl <<
                 "     Default: " << timeout << " s" << std::endl;
             return EXIT_SUCCESS;
@@ -269,15 +269,15 @@ int main(int argc, char *argv[])
                 "  -p enable user to subscribe to specific time base indices" << std::endl <<
                 "  -s subscribe_event_mask" << std::endl <<
                 "     Default: 0x" << std::hex << event2Sub << std::endl <<
-                "     Bit 0: EventGMOffset" << std::endl <<
-                "     Bit 1: EventSyncedToGM" << std::endl <<
-                "     Bit 2: EventASCapable" << std::endl <<
-                "     Bit 3: EventGMChanged" << std::endl <<
+                "     Bit 0: EventOffsetInRange" << std::endl <<
+                "     Bit 1: EventSyncedWithGm" << std::endl <<
+                "     Bit 2: EventAsCapable" << std::endl <<
+                "     Bit 3: EventGmChanged" << std::endl <<
                 "  -c composite_event_mask" << std::endl <<
                 "     Default: 0x" << composite_event << std::endl <<
-                "     Bit 0: EventGMOffset" << std::endl <<
-                "     Bit 1: EventSyncedToGM" << std::endl <<
-                "     Bit 2: EventASCapable" << std::endl <<
+                "     Bit 0: EventOffsetInRange" << std::endl <<
+                "     Bit 1: EventSyncedWithGm" << std::endl <<
+                "     Bit 2: EventAsCapable" << std::endl <<
                 "  -l gm offset threshold (ns)" << std::endl <<
                 "     Default: " << std::dec << ptp4lClockOffsetThreshold << " ns" << std::endl <<
                 "  -i idle time (s)" << std::endl <<
@@ -286,7 +286,7 @@ int main(int argc, char *argv[])
                 "     Default: " << chronyClockOffsetThreshold << " ns" << std::endl <<
                 "  -n chrony_event_mask" << std::endl <<
                 "     Default: 0x" << std::hex << chronyEvent << std::endl <<
-                "     Bit 0: EventGMOffset" << std::endl <<
+                "     Bit 0: EventOffsetInRange" << std::endl <<
                 "  -t timeout in waiting notification event (s)" << std::endl <<
                 "     Default: " << timeout << " s" << std::endl;
             return EXIT_FAILURE;

--- a/clkmgr/utest/clockmanager.cpp
+++ b/clkmgr/utest/clockmanager.cpp
@@ -152,18 +152,18 @@ void TimeBaseStates::setTimeBaseState(size_t timeBaseIndex,
     // Get the current state of the timebase
     PTPClockEvent ptp4lEventState = state.get_ptp4lEventState();
     SysClockEvent chronyEventState = state.get_chronyEventState();
-    // Update EventGMOffset
+    // Update EventOffsetInRange
     ptpClockEventHandler.setClockOffset(ptp4lEventState, 23);
     ptpClockEventHandler.setOffsetInRange(ptp4lEventState, true);
     ptpClockEventHandler.setOffsetInRangeEventCount(ptp4lEventState, 8);
-    // Update EventSyncedToGM
+    // Update EventSyncedWithGm
     ptpClockEventHandler.setSyncedWithGm(ptp4lEventState, true);
     ptpClockEventHandler.setSyncedWithGmEventCount(ptp4lEventState, 9);
-    // Update EventGMChanged
+    // Update EventGmChanged
     ptpClockEventHandler.setGmIdentity(ptp4lEventState, 0x1234ABCD);
     ptpClockEventHandler.setGmChanged(ptp4lEventState, true);
     ptpClockEventHandler.setGmChangedEventCount(ptp4lEventState, 10);
-    // Update EventASCapable
+    // Update EventAsCapable
     ptpClockEventHandler.setAsCapable(ptp4lEventState, true);
     ptpClockEventHandler.setAsCapableEventCount(ptp4lEventState, 11);
     // Update composite event

--- a/debian/make_docker.sh
+++ b/debian/make_docker.sh
@@ -37,7 +37,7 @@ main()
   local dpkgs_arch='libstdc++6 pkgconf
     libpython3-all-dev ruby-dev tcl-dev libpython3-dev libperl-dev
     libfastjson-dev libgtest-dev libgmock-dev lua-posix libjson-c-dev
-    libssl-dev libgcrypt20 libgnutls28-dev nettle-dev'
+    libssl-dev libgcrypt20 libgnutls28-dev nettle-dev libsystemd-dev'
   for n in 1-0 {2..4};do dpkgs_arch+=" liblua5.$n-dev";done
   local no_cache use_srv srv_ns args dock_file use_b use_f
   tool_docker_get_opts "$@"

--- a/gentoo/Dockerfile
+++ b/gentoo/Dockerfile
@@ -14,6 +14,8 @@
 # --sync                Updates repositories
 # --depclean, -c        Cleans the system by removing packages
 #                       that are not associated with explicitly merged packages
+# --fetchonly, -f       Fetches for all packages based upon USE setting
+# --color n             Disable color
 ###############################################################################
 FROM portage.2
 ARG UID USER

--- a/gentoo/Dockerfile.1
+++ b/gentoo/Dockerfile.1
@@ -5,7 +5,7 @@
 # @copyright © 2023 Erez Geva
 #
 # Docker file for stage 1 of Gentoo container for building and installing
-# Search packages at: https://packages.gentoo.org/categories
+# Search packages at: https://packages.gentoo.org/
 ###############################################################################
 FROM gentoo/stage3
 MAINTAINER "Erez Geva" <ErezGeva2@gmail.com>

--- a/rpm/Dockerfile
+++ b/rpm/Dockerfile
@@ -20,7 +20,7 @@ RUN dnf install -y gcc gcc-c++ libtool libtool-ltdl make cmake git pkgconfig\
     libfastjson libfastjson-devel json-c-devel m4 rubygem-test-unit gdb tclx\
     texlive-epstopdf ghostscript php-phpunit-PHPUnit perl-File-Touch jq\
     chrpath patchelf discount gmock-devel cppcheck chrony quilt cmark tcllib\
-    && dnf clean all &&\
+    systemd-devel && dnf clean all &&\
     sed -i 's/^enable_dl\s*=\s*Off/enable_dl = On/' /etc/php.ini &&\
     useradd $USER -u $UID -m -G users,wheel &&\
     echo "$USER ALL=(ALL:ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/rpm/make_docker.sh
+++ b/rpm/make_docker.sh
@@ -27,6 +27,8 @@ dnf list installed
 rpm -qf file
 # See package scripts
 rpm -qlp --scripts clkmgr-proxy-1*.x86_64.rpm
+# Search For Packages
+dnf search php
 
 docker run -it -w /home/builder/libptpmgmt -u builder\
   -v $(realpath .):/home/builder/rpm rpmbuild

--- a/wrappers/go/clkmgr_gtest/clkmgr_gtest.go
+++ b/wrappers/go/clkmgr_gtest/clkmgr_gtest.go
@@ -31,11 +31,11 @@ import (
 )
 
 var clockSyncData clkmgr.ClockSyncData
-var event2Sub uint = uint(clkmgr.EventGMOffset | clkmgr.EventSyncedToGM |
-        clkmgr.EventASCapable | clkmgr.EventGMChanged)
-var composite_event uint = uint(clkmgr.EventGMOffset | clkmgr.EventSyncedToGM |
-        clkmgr.EventASCapable)
-var chronyEvent uint = uint(clkmgr.EventGMOffset)
+var event2Sub uint = uint(clkmgr.EventOffsetInRange | clkmgr.EventSyncedWithGm |
+        clkmgr.EventAsCapable | clkmgr.EventGmChanged)
+var composite_event uint = uint(clkmgr.EventOffsetInRange |
+        clkmgr.EventSyncedWithGm | clkmgr.EventAsCapable)
+var chronyEvent uint = uint(clkmgr.EventOffsetInRange)
 
 func deleteOverallSub(overallSub []clkmgr.ClockSyncSubscription) {
     for _, subscribe := range overallSub {
@@ -82,37 +82,37 @@ func printOut() {
         fmt.Printf(hd3b + "\n", "ptp_isCompositeEventMet",
                 ptpClock.IsCompositeEventMet(),
                 ptpClock.GetCompositeEventCount())
-        if composite_event & uint(clkmgr.EventGMOffset) > 0 {
+        if composite_event & uint(clkmgr.EventOffsetInRange) > 0 {
             fmt.Printf("| - %-26s | %-12s | %-11s |\n",
                     "isOffsetInRange", "", "")
         }
-        if composite_event & uint(clkmgr.EventSyncedToGM) > 0 {
+        if composite_event & uint(clkmgr.EventSyncedWithGm) > 0 {
             fmt.Printf("| - %-26s | %-12s | %-11s |\n",
                     "isSyncedWithGm", "", "")
         }
-        if composite_event & uint(clkmgr.EventASCapable) > 0 {
+        if composite_event & uint(clkmgr.EventAsCapable) > 0 {
             fmt.Printf("| - %-26s | %-12s | %-11s |\n",
                     "isAsCapable", "", "")
         }
         fmt.Println(hd3)
     }
     if event2Sub != 0 {
-        if event2Sub & uint(clkmgr.EventGMOffset) > 0 {
+        if event2Sub & uint(clkmgr.EventOffsetInRange) > 0 {
             fmt.Printf(hd3b + "\n", "ptp_isOffsetInRange",
                     ptpClock.IsOffsetInRange(),
                     ptpClock.GetOffsetInRangeEventCount())
         }
-        if event2Sub & uint(clkmgr.EventSyncedToGM) > 0 {
+        if event2Sub & uint(clkmgr.EventSyncedWithGm) > 0 {
             fmt.Printf(hd3b + "\n", "ptp_isSyncedWithGm",
                     ptpClock.IsSyncedWithGm(),
                     ptpClock.GetSyncedWithGmEventCount())
         }
-        if event2Sub & uint(clkmgr.EventASCapable) > 0 {
+        if event2Sub & uint(clkmgr.EventAsCapable) > 0 {
             fmt.Printf(hd3b + "\n", "ptp_isAsCapable",
                     ptpClock.IsAsCapable(),
                     ptpClock.GetAsCapableEventCount())
         }
-        if event2Sub & uint(clkmgr.EventGMChanged) > 0 {
+        if event2Sub & uint(clkmgr.EventGmChanged) > 0 {
             fmt.Printf(hd3b + "\n", "ptp_isGmChanged",
                     ptpClock.IsGmChanged(),
                     ptpClock.GetGmChangedEventCount())
@@ -220,18 +220,18 @@ Options:
   -p enable user to subscribe to specific time base indices
   -s subscribe_event_mask
      Default: ` + fmt.Sprintf("0x%x", event2Sub) + `
-     Bit 0: EventGMOffset
-     Bit 1: EventSyncedToGM
-     Bit 2: EventASCapable
-     Bit 3: EventGMChanged
+     Bit 0: EventOffsetInRange
+     Bit 1: EventSyncedWithGm
+     Bit 2: EventAsCapable
+     Bit 3: EventGmChanged
   -c composite_event_mask
      Default: ` + fmt.Sprintf("0x%x", composite_event) + `
-     Bit 0: EventGMOffset
-     Bit 1: EventSyncedToGM
-     Bit 2: EventASCapable
+     Bit 0: EventOffsetInRange
+     Bit 1: EventSyncedWithGm
+     Bit 2: EventAsCapable
   -n chrony_event_mask
      Default: ` + fmt.Sprintf("0x%x", chronyEvent) + `
-     Bit 0: EventGMOffset
+     Bit 0: EventOffsetInRange
   -l gm offset threshold (ns)
      Default: ` + strconv.Itoa(int(ptp4lClockOffsetThreshold)) + ` ns
   -i idle time (s)

--- a/wrappers/lua/clkmgr_test.lua
+++ b/wrappers/lua/clkmgr_test.lua
@@ -22,11 +22,11 @@ local time = require 'posix.time'
 local signal_flag = false
 
 -- Global variables for event configuration and clock sync data
-local event2Sub = clkmgr.EventGMOffset + clkmgr.EventSyncedToGM +
-    clkmgr.EventASCapable + clkmgr.EventGMChanged
-local composite_event = clkmgr.EventGMOffset +
-    clkmgr.EventSyncedToGM + clkmgr.EventASCapable
-local chrony_event = clkmgr.EventGMOffset
+local event2Sub = clkmgr.EventOffsetInRange + clkmgr.EventSyncedWithGm +
+    clkmgr.EventAsCapable + clkmgr.EventGmChanged
+local composite_event = clkmgr.EventOffsetInRange +
+    clkmgr.EventSyncedWithGm + clkmgr.EventAsCapable
+local chrony_event = clkmgr.EventOffsetInRange
 local clockSyncData = clkmgr.ClockSyncData()
 
 local function signal_handler(signo)
@@ -115,15 +115,15 @@ local function printOut()
         print(string.format(hd3b, 'ptp_isCompositeEventMet',
             tostring(ptpClock:isCompositeEventMet()),
             ptpClock:getCompositeEventCount()))
-        if haveFlag(composite_event, clkmgr.EventGMOffset) then
+        if haveFlag(composite_event, clkmgr.EventOffsetInRange) then
             print(string.format('| - %-26s | %-12s | %-11s |',
                 'isOffsetInRange', '', ''))
         end
-        if haveFlag(composite_event, clkmgr.EventSyncedToGM) then
+        if haveFlag(composite_event, clkmgr.EventSyncedWithGm) then
             print(string.format('| - %-26s | %-12s | %-11s |',
                 'isSyncedWithGm', '', ''))
         end
-        if haveFlag(composite_event, clkmgr.EventASCapable) then
+        if haveFlag(composite_event, clkmgr.EventAsCapable) then
             print(string.format('| - %-26s | %-12s | %-11s |',
                 'isAsCapable', '', ''))
         end
@@ -131,22 +131,22 @@ local function printOut()
 
     if event2Sub ~= 0 then
         print(hd3)
-        if haveFlag(event2Sub, clkmgr.EventGMOffset) then
+        if haveFlag(event2Sub, clkmgr.EventOffsetInRange) then
             print(string.format(hd3b, 'ptp_isOffsetInRange',
                 tostring(ptpClock:isOffsetInRange()),
                 ptpClock:getOffsetInRangeEventCount()))
         end
-        if haveFlag(event2Sub, clkmgr.EventSyncedToGM) then
+        if haveFlag(event2Sub, clkmgr.EventSyncedWithGm) then
             print(string.format(hd3b, 'ptp_isSyncedWithGm',
                 tostring(ptpClock:isSyncedWithGm()),
                 ptpClock:getSyncedWithGmEventCount()))
         end
-        if haveFlag(event2Sub, clkmgr.EventASCapable) then
+        if haveFlag(event2Sub, clkmgr.EventAsCapable) then
             print(string.format(hd3b, 'ptp_isAsCapable',
                 tostring(ptpClock:isAsCapable()),
                 ptpClock:getAsCapableEventCount()))
         end
-        if haveFlag(event2Sub, clkmgr.EventGMChanged) then
+        if haveFlag(event2Sub, clkmgr.EventGmChanged) then
             print(string.format(hd3b, 'ptp_isGmChanged',
                 tostring(ptpClock:isGmChanged()),
                 ptpClock:getGmChangedEventCount()))
@@ -257,18 +257,18 @@ Options:
   -p enable user to subscribe to specific time base indices
   -s subscribe_event_mask
      Default: ]=] .. string.format('0x%x\n', event2Sub) .. [=[
-     Bit 0: EventGMOffset
-     Bit 1: EventSyncedToGM
-     Bit 2: EventASCapable
-     Bit 3: EventGMChanged
+     Bit 0: EventOffsetInRange
+     Bit 1: EventSyncedWithGm
+     Bit 2: EventAsCapable
+     Bit 3: EventGmChanged
   -c composite_event_mask
      Default: ]=] .. string.format('0x%x\n', composite_event) .. [=[
-     Bit 0: EventGMOffset
-     Bit 1: EventSyncedToGM
-     Bit 2: EventASCapable
+     Bit 0: EventOffsetInRange
+     Bit 1: EventSyncedWithGm
+     Bit 2: EventAsCapable
   -n chrony_event_mask
      Default: ]=] .. string.format('0x%x\n', chrony_event) .. [=[
-     Bit 0: EventGMOffset
+     Bit 0: EventOffsetInRange
   -l gm offset threshold (ns)
      Default: ]=] .. ptp4lClockOffsetThreshold .. [=[ ns
   -i idle time (s)

--- a/wrappers/perl/clkmgr_test.pl
+++ b/wrappers/perl/clkmgr_test.pl
@@ -24,11 +24,11 @@ use ClkMgrLib;
 
 my $signal_flag :shared = 0;
 my $clockSyncData = ClkMgrLib::ClockSyncData->new;
-my $event2Sub = $ClkMgrLib::EventGMOffset | $ClkMgrLib::EventSyncedToGM |
-    $ClkMgrLib::EventASCapable | $ClkMgrLib::EventGMChanged;
-my $composite_event = $ClkMgrLib::EventGMOffset |
-    $ClkMgrLib::EventSyncedToGM | $ClkMgrLib::EventASCapable;
-my $chrony_event = $ClkMgrLib::EventGMOffset;
+my $event2Sub = $ClkMgrLib::EventOffsetInRange | $ClkMgrLib::EventSyncedWithGm |
+    $ClkMgrLib::EventAsCapable | $ClkMgrLib::EventGmChanged;
+my $composite_event = $ClkMgrLib::EventOffsetInRange |
+    $ClkMgrLib::EventSyncedWithGm | $ClkMgrLib::EventAsCapable;
+my $chrony_event = $ClkMgrLib::EventOffsetInRange;
 
 sub signal_handler()
 {
@@ -78,29 +78,29 @@ sub printOut
             $ptpClock->isCompositeEventMet(),
             $ptpClock->getCompositeEventCount();
         printf "| - %-26s | %-12s | %-11s |\n", 'isOffsetInRange', '', ''
-            if $composite_event & $ClkMgrLib::EventGMOffset;
+            if $composite_event & $ClkMgrLib::EventOffsetInRange;
         printf "| - %-26s | %-12s | %-11s |\n",
             'isSyncedWithGm', '', ''
-            if $composite_event & $ClkMgrLib::EventSyncedToGM;
+            if $composite_event & $ClkMgrLib::EventSyncedWithGm;
         printf "| - %-26s | %-12s | %-11s |\n", 'isAsCapable', '', ''
-            if $composite_event & $ClkMgrLib::EventASCapable;
+            if $composite_event & $ClkMgrLib::EventAsCapable;
     }
     if ($event2Sub != 0) {
         print "$hd3\n";
         printf "$hd3b\n", 'ptp_isOffsetInRange',
             $ptpClock->isOffsetInRange(),
             $ptpClock->getOffsetInRangeEventCount()
-            if $event2Sub & $ClkMgrLib::EventGMOffset;
+            if $event2Sub & $ClkMgrLib::EventOffsetInRange;
         printf "$hd3b\n", 'ptp_isSyncedWithGm',
             $ptpClock->isSyncedWithGm(),
             $ptpClock->getSyncedWithGmEventCount()
-            if $event2Sub & $ClkMgrLib::EventSyncedToGM;
+            if $event2Sub & $ClkMgrLib::EventSyncedWithGm;
         printf "$hd3b\n", 'ptp_isAsCapable',
             $ptpClock->isAsCapable(), $ptpClock->getAsCapableEventCount()
-            if $event2Sub & $ClkMgrLib::EventASCapable;
+            if $event2Sub & $ClkMgrLib::EventAsCapable;
         printf "$hd3b\n", 'ptp_isGmChanged',
             $ptpClock->isGmChanged(), $ptpClock->getGmChangedEventCount()
-            if $event2Sub & $ClkMgrLib::EventGMChanged;
+            if $event2Sub & $ClkMgrLib::EventGmChanged;
     }
     print "$hd3\n";
 
@@ -183,18 +183,18 @@ Options:
   -p enable user to subscribe to specific time base indices
   -s subscribe_event_mask
      Default: $event2SubHex
-     Bit 0: EventGMOffset
-     Bit 1: EventSyncedToGM
-     Bit 2: EventASCapable
-     Bit 3: EventGMChanged
+     Bit 0: EventOffsetInRange
+     Bit 1: EventSyncedWithGm
+     Bit 2: EventAsCapable
+     Bit 3: EventGmChanged
   -c composite_event_mask
      Default: $composite_eventHex
-     Bit 0: EventGMOffset
-     Bit 1: EventSyncedToGM
-     Bit 2: EventASCapable
+     Bit 0: EventOffsetInRange
+     Bit 1: EventSyncedWithGm
+     Bit 2: EventAsCapable
   -n chrony_event_mask
      Default: $chrony_eventHex
-     Bit 0: EventGMOffset
+     Bit 0: EventOffsetInRange
   -l gm offset threshold (ns)
      Default: $ptp4lClockOffsetThreshold ns
   -i idle time (s)

--- a/wrappers/perl/clkmgr_test.pl
+++ b/wrappers/perl/clkmgr_test.pl
@@ -127,7 +127,16 @@ sub printOut
         my $identity_string = '';
         for my $i (0..3) {
             my $byte = ($sysClock->getGmIdentity() >> (8 * (3 - $i))) & 0xFF;
-            $identity_string .= chr($byte);
+            if($byte == 0 || $byte == 9) {
+                $identity_string .= ' ';
+            } else {
+                my $s = chr($byte);
+                if($s =~ /[[:print:]]/) {
+                    $identity_string .= $s;
+                } else {
+                    $identity_string .= '.';
+                }
+            }
         }
         printf "$hd3b\n" .
             "$hd2l\n" .

--- a/wrappers/php/clkmgr_test.php
+++ b/wrappers/php/clkmgr_test.php
@@ -28,7 +28,7 @@ declare(ticks = 1);
 function signal_handler(int $signo, $siginfo): void
 {
     global $signal_flag;
-    echo " Exit ..." . PHP_EOL;
+    echo ' Exit ...' . PHP_EOL;
     $signal_flag = true;
 }
 
@@ -45,10 +45,10 @@ function clockManagerGetTime(): void
 {
     $ts = new timespec();
     if(ClockManager::getTime($ts)) {
-        printf("[clkmgr] Current Time of CLOCK_REALTIME: %ld ns" . PHP_EOL,
+        printf('[clkmgr] Current Time of CLOCK_REALTIME: %ld ns' . PHP_EOL,
                 ($ts->tv_sec * 1000000000) + $ts->tv_nsec);
     } else {
-        echo "clock_gettime failed: " . posix_strerror(posix_get_last_error()). PHP_EOL;
+        echo 'clock_gettime failed: ' . posix_strerror(posix_get_last_error()). PHP_EOL;
     }
 }
 
@@ -64,53 +64,62 @@ function printOut(): void
     $hd3b = '| %-28s | %-12d | %-11d |';
     $hd3 = '|'.str_repeat('-', 30).'|'.str_repeat('-', 14).'|'.str_repeat('-', 13).'|';
     clockManagerGetTime();
-    printf("$hd3\n| %-28s | %-12s | %-11s |\n", 'Events', 'Event Status', 'Event Count');
+    printf($hd3 . PHP_EOL . '| %-28s | %-12s | %-11s |' . PHP_EOL, 'Events', 'Event Status', 'Event Count');
     $ptpClock = $clockSyncData->getPtp();
     $sysClock = $clockSyncData->getSysClock();
     if($composite_event != 0) {
-        echo "$hd3\n";
-        printf("$hd3b\n", 'ptp_isCompositeEventMet', $ptpClock->isCompositeEventMet(), $ptpClock->getCompositeEventCount());
+        echo $hd3 . PHP_EOL;
+        printf($hd3b . PHP_EOL, 'ptp_isCompositeEventMet', $ptpClock->isCompositeEventMet(), $ptpClock->getCompositeEventCount());
         if($composite_event & EventGMOffset)
-            printf("| - %-26s | %-12s | %-11s |\n", 'isOffsetInRange', '', '');
+            printf('| - %-26s | %-12s | %-11s |' . PHP_EOL, 'isOffsetInRange', '', '');
         if($composite_event & EventSyncedToGM)
-            printf("| - %-26s | %-12s | %-11s |\n", 'isSyncedWithGm', '', '');
+            printf('| - %-26s | %-12s | %-11s |' . PHP_EOL, 'isSyncedWithGm', '', '');
         if($composite_event & EventASCapable)
-            printf("| - %-26s | %-12s | %-11s |\n", 'isAsCapable', '', '');
+            printf('| - %-26s | %-12s | %-11s |' . PHP_EOL, 'isAsCapable', '', '');
     }
     if($event2Sub != 0) {
-        echo "$hd3\n";
+        echo $hd3 . PHP_EOL;
         if($event2Sub & EventGMOffset)
-            printf("$hd3b\n", 'ptp_isOffsetInRange', $ptpClock->isOffsetInRange(), $ptpClock->getOffsetInRangeEventCount());
+            printf($hd3b . PHP_EOL, 'ptp_isOffsetInRange', $ptpClock->isOffsetInRange(), $ptpClock->getOffsetInRangeEventCount());
         if($event2Sub & EventSyncedToGM)
-            printf("$hd3b\n", 'ptp_isSyncedWithGm', $ptpClock->isSyncedWithGm(), $ptpClock->getSyncedWithGmEventCount());
+            printf($hd3b . PHP_EOL, 'ptp_isSyncedWithGm', $ptpClock->isSyncedWithGm(), $ptpClock->getSyncedWithGmEventCount());
         if($event2Sub & EventASCapable)
-            printf("$hd3b\n", 'ptp_isAsCapable', $ptpClock->isAsCapable(), $ptpClock->getAsCapableEventCount());
+            printf($hd3b . PHP_EOL, 'ptp_isAsCapable', $ptpClock->isAsCapable(), $ptpClock->getAsCapableEventCount());
         if($event2Sub & EventGMChanged)
-            printf("$hd3b\n", 'ptp_isGmChanged', $ptpClock->isGmChanged(), $ptpClock->getGmChangedEventCount());
+            printf($hd3b . PHP_EOL, 'ptp_isGmChanged', $ptpClock->isGmChanged(), $ptpClock->getGmChangedEventCount());
     }
-    echo "$hd3\n";
+    echo $hd3 . PHP_EOL;
     $gmClockUUID = $ptpClock->getGmIdentityStr();
-    printf("| %-28s |     %-19ld ns |\n" , 'ptp_clockOffset', $ptpClock->getClockOffset());
-    printf("| %-28s |     %s     |\n", 'ptp_gmIdentity', $gmClockUUID);
-    printf("| %-28s |     %-19ld us |\n" .
-           "| %-28s |     %-19ld ns |\n"
+    printf('| %-28s |     %-19ld ns |' . PHP_EOL , 'ptp_clockOffset', $ptpClock->getClockOffset());
+    printf('| %-28s |     %s     |' . PHP_EOL, 'ptp_gmIdentity', $gmClockUUID);
+    printf('| %-28s |     %-19ld us |' . PHP_EOL .
+           '| %-28s |     %-19ld ns |' . PHP_EOL
            , 'ptp_syncInterval', $ptpClock->getSyncInterval()
            , 'ptp_notificationTimestamp', $ptpClock->getNotificationTimestamp());
+    echo $hd2l . PHP_EOL;
     if($clockSyncData->haveSys() != 0) {
-        $identityString = "";
+        $identityString = '';
         $gmIdentity = $sysClock->getGmIdentity();
         for ($i = 0; $i < 4; $i++) {
             $byte = ($gmIdentity >> (8 * (3 - $i))) & 0xFF;
-            $identityString .= chr($byte);
+            if($byte == 0 || $byte == 9) {
+                $identityString .= ' ';
+            } else {
+                $s = chr($byte);
+                if(preg_match('/[[:print:]]/', $s)) {
+                    $identityString .= $s;
+                } else {
+                    $identityString .= '.';
+                }
+            }
         }
-        printf("$hd2l\n" .
-            "$hd3b\n" .
-            "$hd2l\n" .
-            "| %-28s |     %-19ld ns |\n" .
-            "| %-28s |     %-19s    |\n" .
-            "| %-28s |     %-19ld us |\n" .
-            "| %-28s |     %-19ld ns |\n" .
-            "$hd2l\n\n"
+        printf($hd3b . PHP_EOL .
+            $hd2l . PHP_EOL .
+            '| %-28s |     %-19ld ns |' . PHP_EOL .
+            '| %-28s |     %-19s    |' . PHP_EOL .
+            '| %-28s |     %-19ld us |' . PHP_EOL .
+            '| %-28s |     %-19ld ns |' . PHP_EOL .
+            $hd2l . PHP_EOL . PHP_EOL
             , 'chrony_isOffsetInRange', $sysClock->isOffsetInRange(),
                 $sysClock->getOffsetInRangeEventCount()
             , 'chrony_clockOffset', $sysClock->getClockOffset()
@@ -198,12 +207,12 @@ function main(): void
     $ptp4lSub->setCompositeEventMask($composite_event);
     $chronySub->setEventMask($chrony_event);
     $chronySub->setClockOffsetThreshold($chronyClockOffsetThreshold);
-    echo "[clkmgr] set subscribe event : 0x" .
+    echo '[clkmgr] set subscribe event : 0x' .
         dechex($ptp4lSub->getEventMask()) . PHP_EOL;
-    echo "[clkmgr] set composite event : 0x" .
+    echo '[clkmgr] set composite event : 0x' .
         dechex($ptp4lSub->getCompositeEventMask()) . PHP_EOL;
     echo "GM Offset threshold: $ptp4lClockOffsetThreshold ns" . PHP_EOL;
-    echo "[clkmgr] set chrony event : 0x" .
+    echo '[clkmgr] set chrony event : 0x' .
         dechex($chronySub->getEventMask()) . PHP_EOL;
     echo "Chrony Offset threshold: $chronyClockOffsetThreshold ns" . PHP_EOL;
 
@@ -220,12 +229,12 @@ function main(): void
                 $index[] = $idx;
             }
         } else {
-            echo "Invalid input. Using default time base index 1." . PHP_EOL;
+            echo 'Invalid input. Using default time base index 1.' . PHP_EOL;
         }
     }
-    pcntl_signal(SIGINT, "signal_handler");
-    pcntl_signal(SIGTERM, "signal_handler");
-    pcntl_signal(SIGHUP, "signal_handler");
+    pcntl_signal(SIGINT, 'signal_handler');
+    pcntl_signal(SIGTERM, 'signal_handler');
+    pcntl_signal(SIGHUP, 'signal_handler');
 
     $dieMsg = '';
     if(!ClockManager::connect()) {
@@ -233,7 +242,7 @@ function main(): void
         goto do_exit;
     }
     sleep(1);
-    echo "[clkmgr] List of available clock:" . PHP_EOL;
+    echo '[clkmgr] List of available clock:' . PHP_EOL;
 
     # Print out each member of the Time Base configuration
     $size = TimeBaseConfigurations::size();
@@ -271,7 +280,7 @@ function main(): void
             $dieMsg = '[clkmgr] Failure in subscribing to clkmgr Proxy !!!';
             goto do_exit;
         }
-        printf("[clkmgr][%.3f] Obtained data from Subscription Event:" . PHP_EOL,
+        printf('[clkmgr][%.3f] Obtained data from Subscription Event:' . PHP_EOL,
             getMonotonicTime());
         printOut();
     }
@@ -287,20 +296,20 @@ function main(): void
         foreach($index as $idx) {
             if($signal_flag)
                 goto do_exit;
-            printf("[clkmgr][%.3f] Waiting Notification from " .
+            printf('[clkmgr][%.3f] Waiting Notification from ' .
                 "time base index $idx ..." . PHP_EOL, getMonotonicTime());
             $retval = ClockManager::statusWait($timeout, $idx, $clockSyncData);
             switch($retval) {
                 case SWRLostConnection:
-                    printf("[clkmgr][%.3f] Terminating: " .
-                        "lost connection to clkmgr Proxy" . PHP_EOL, getMonotonicTime());
+                    printf('[clkmgr][%.3f] Terminating: ' .
+                        'lost connection to clkmgr Proxy' . PHP_EOL, getMonotonicTime());
                     goto do_exit;
                 case SWRInvalidArgument:
-                    $dieMsg = sprintf("[clkmgr][%.3f] Terminating: Invalid argument" . PHP_EOL,
+                    $dieMsg = sprintf('[clkmgr][%.3f] Terminating: Invalid argument' . PHP_EOL,
                         getMonotonicTime());
                     goto do_exit;
                 case SWRNoEventDetected:
-                    printf("[clkmgr][%.3f] No event status changes identified " .
+                    printf('[clkmgr][%.3f] No event status changes identified ' .
                         "in $timeout seconds." . PHP_EOL . PHP_EOL, getMonotonicTime());
                     printf("[clkmgr][%.3f] sleep for $idleTime seconds..." . PHP_EOL . PHP_EOL,
                         getMonotonicTime());
@@ -309,17 +318,17 @@ function main(): void
                     sleep($idleTime);
                     goto next_loop;
                 case SWREventDetected:
-                    printf("[clkmgr][%.3f] Obtained data from Notification Event:" . PHP_EOL,
+                    printf('[clkmgr][%.3f] Obtained data from Notification Event:' . PHP_EOL,
                         getMonotonicTime());
                     break;
                 default:
-                    printf("[clkmgr][%.3f] Warning: Should not enter " .
+                    printf('[clkmgr][%.3f] Warning: Should not enter ' .
                            "this switch case, unexpected status code $retval" . PHP_EOL,
                            getMonotonicTime());
                     goto do_exit;
             }
             printOut();
-            printf("[clkmgr][%.3f] sleep for %d seconds..." . PHP_EOL . PHP_EOL,
+            printf('[clkmgr][%.3f] sleep for %d seconds...' . PHP_EOL . PHP_EOL,
                 getMonotonicTime(), $idleTime);
             if($signal_flag)
                 goto do_exit;

--- a/wrappers/php/clkmgr_test.php
+++ b/wrappers/php/clkmgr_test.php
@@ -18,9 +18,9 @@
  */
 
 $signal_flag = false;
-$event2Sub = EventGMOffset | EventSyncedToGM | EventASCapable | EventGMChanged;
-$composite_event = EventGMOffset | EventSyncedToGM | EventASCapable;
-$chrony_event = EventGMOffset;
+$event2Sub = EventOffsetInRange | EventSyncedWithGm | EventAsCapable | EventGmChanged;
+$composite_event = EventOffsetInRange | EventSyncedWithGm | EventAsCapable;
+$chrony_event = EventOffsetInRange;
 $clockSyncData = null;
 
 declare(ticks = 1);
@@ -70,22 +70,22 @@ function printOut(): void
     if($composite_event != 0) {
         echo $hd3 . PHP_EOL;
         printf($hd3b . PHP_EOL, 'ptp_isCompositeEventMet', $ptpClock->isCompositeEventMet(), $ptpClock->getCompositeEventCount());
-        if($composite_event & EventGMOffset)
+        if($composite_event & EventOffsetInRange)
             printf('| - %-26s | %-12s | %-11s |' . PHP_EOL, 'isOffsetInRange', '', '');
-        if($composite_event & EventSyncedToGM)
+        if($composite_event & EventSyncedWithGm)
             printf('| - %-26s | %-12s | %-11s |' . PHP_EOL, 'isSyncedWithGm', '', '');
-        if($composite_event & EventASCapable)
+        if($composite_event & EventAsCapable)
             printf('| - %-26s | %-12s | %-11s |' . PHP_EOL, 'isAsCapable', '', '');
     }
     if($event2Sub != 0) {
         echo $hd3 . PHP_EOL;
-        if($event2Sub & EventGMOffset)
+        if($event2Sub & EventOffsetInRange)
             printf($hd3b . PHP_EOL, 'ptp_isOffsetInRange', $ptpClock->isOffsetInRange(), $ptpClock->getOffsetInRangeEventCount());
-        if($event2Sub & EventSyncedToGM)
+        if($event2Sub & EventSyncedWithGm)
             printf($hd3b . PHP_EOL, 'ptp_isSyncedWithGm', $ptpClock->isSyncedWithGm(), $ptpClock->getSyncedWithGmEventCount());
-        if($event2Sub & EventASCapable)
+        if($event2Sub & EventAsCapable)
             printf($hd3b . PHP_EOL, 'ptp_isAsCapable', $ptpClock->isAsCapable(), $ptpClock->getAsCapableEventCount());
-        if($event2Sub & EventGMChanged)
+        if($event2Sub & EventGmChanged)
             printf($hd3b . PHP_EOL, 'ptp_isGmChanged', $ptpClock->isGmChanged(), $ptpClock->getGmChangedEventCount());
     }
     echo $hd3 . PHP_EOL;
@@ -157,18 +157,18 @@ function main(): void
           -p enable user to subscribe to specific time base indices
           -s subscribe_event_mask
              Default: 0x$event2SubHex
-             Bit 0: EventGMOffset
-             Bit 1: EventSyncedToGM
-             Bit 2: EventASCapable
-             Bit 3: EventGMChanged
+             Bit 0: EventOffsetInRange
+             Bit 1: EventSyncedWithGm
+             Bit 2: EventAsCapable
+             Bit 3: EventGmChanged
           -c composite_event_mask
              Default: 0x$composite_eventHex
-             Bit 0: EventGMOffset
-             Bit 1: EventSyncedToGM
-             Bit 2: EventASCapable
+             Bit 0: EventOffsetInRange
+             Bit 1: EventSyncedWithGm
+             Bit 2: EventAsCapable
           -n chrony_event_mask
              Default: 0x$chrony_eventHex
-             Bit 0: EventGMOffset
+             Bit 0: EventOffsetInRange
           -l gm offset threshold (ns)
              Default: $ptp4lClockOffsetThreshold ns
           -i idle time (s)

--- a/wrappers/python/clkmgr_test.py
+++ b/wrappers/python/clkmgr_test.py
@@ -115,9 +115,17 @@ def printOut():
         print(hd3b % ('chrony_isOffsetInRange', sysClock.isOffsetInRange(), sysClock.getOffsetInRangeEventCount()))
         print(hd2l)
         print('| %-28s |     %-19ld ns |' % ('chrony_clockOffset', sysClock.getClockOffset()))
-        identity_string = ''.join(
-            chr((sysClock.getGmIdentity() >> (8 * (3 - i))) & 0xFF) for i in range(4)
-        )
+        identity_string = ''
+        for i in range(4):
+            byteVal = (sysClock.getGmIdentity() >> (8 * (3 - i))) & 0xFF
+            if byteVal == 0 or byteVal == 9:
+                identity_string += ' '
+            else:
+                s = chr(byteVal) + ''
+                if s.isprintable():
+                    identity_string += s
+                else:
+                    identity_string += '.'
         print('| %-28s |     %-19s    |' % ('chrony_gmIdentity', identity_string))
         print('| %-28s |     %-19ld us |' % ('chrony_syncInterval', sysClock.getSyncInterval()))
         print('| %-28s |     %-19ld ns |' % ('chrony_notificationTimestamp', sysClock.getNotificationTimestamp()))

--- a/wrappers/python/clkmgr_test.py
+++ b/wrappers/python/clkmgr_test.py
@@ -31,11 +31,11 @@ userInput = False
 idleTime = 1
 timeout = 10
 clockSyncData = clkmgr.ClockSyncData()
-event2Sub = (clkmgr.EventGMOffset | clkmgr.EventSyncedToGM |
-    clkmgr.EventASCapable | clkmgr.EventGMChanged)
-composite_event = (clkmgr.EventGMOffset | clkmgr.EventSyncedToGM |
-    clkmgr.EventASCapable)
-chrony_event = clkmgr.EventGMOffset
+event2Sub = (clkmgr.EventOffsetInRange | clkmgr.EventSyncedWithGm |
+    clkmgr.EventAsCapable | clkmgr.EventGmChanged)
+composite_event = (clkmgr.EventOffsetInRange | clkmgr.EventSyncedWithGm |
+    clkmgr.EventAsCapable)
+chrony_event = clkmgr.EventOffsetInRange
 # Subscribe data
 ptp4lSub = clkmgr.PTPClockSubscription()
 chronySub = clkmgr.SysClockSubscription()
@@ -81,21 +81,21 @@ def printOut():
     print(hd3)
     if composite_event != 0:
         print(hd3b % ('ptp_isCompositeEventMet', ptpClock.isCompositeEventMet(), ptpClock.getCompositeEventCount()))
-        if composite_event & clkmgr.EventGMOffset:
+        if composite_event & clkmgr.EventOffsetInRange:
             print('| - %-26s | %-12s | %-11s |' % ('isOffsetInRange', '', ''))
-        if composite_event & clkmgr.EventSyncedToGM:
+        if composite_event & clkmgr.EventSyncedWithGm:
             print('| - %-26s | %-12s | %-11s |' % ('isSyncedWithGm', '', ''))
-        if composite_event & clkmgr.EventASCapable:
+        if composite_event & clkmgr.EventAsCapable:
             print('| - %-26s | %-12s | %-11s |' % ('isAsCapable', '', ''))
     if event2Sub != 0:
         print(hd3)
-        if event2Sub & clkmgr.EventGMOffset:
+        if event2Sub & clkmgr.EventOffsetInRange:
             print(hd3b % ('ptp_isOffsetInRange', ptpClock.isOffsetInRange(), ptpClock.getOffsetInRangeEventCount()))
-        if event2Sub & clkmgr.EventSyncedToGM:
+        if event2Sub & clkmgr.EventSyncedWithGm:
             print(hd3b % ('ptp_isSyncedWithGm', ptpClock.isSyncedWithGm(), ptpClock.getSyncedWithGmEventCount()))
-        if event2Sub & clkmgr.EventASCapable:
+        if event2Sub & clkmgr.EventAsCapable:
             print(hd3b % ('ptp_isAsCapable', ptpClock.isAsCapable(), ptpClock.getAsCapableEventCount()))
-        if event2Sub & clkmgr.EventGMChanged:
+        if event2Sub & clkmgr.EventGmChanged:
             print(hd3b % ('ptp_isGmChanged', ptpClock.isGmChanged(), ptpClock.getGmChangedEventCount()))
     print(hd3)
     print('| %-28s |     %-19ld ns |' % ('ptp_clockOffset', ptpClock.getClockOffset()))
@@ -141,18 +141,18 @@ Options:
   -p enable user to subscribe to specific time base indices
   -s subscribe_event_mask
      Default: {}
-     Bit 0: EventGMOffset
-     Bit 1: EventSyncedToGM
-     Bit 2: EventASCapable
-     Bit 3: EventGMChanged
+     Bit 0: EventOffsetInRange
+     Bit 1: EventSyncedWithGm
+     Bit 2: EventAsCapable
+     Bit 3: EventGmChanged
   -c composite_event_mask
      Default: {}
-     Bit 0: EventGMOffset
-     Bit 1: EventSyncedToGM
-     Bit 2: EventASCapable
+     Bit 0: EventOffsetInRange
+     Bit 1: EventSyncedWithGm
+     Bit 2: EventAsCapable
   -n chrony_event_mask
      Default: {}
-     Bit 0: EventGMOffset
+     Bit 0: EventOffsetInRange
   -l gm offset threshold (ns)
      Default: {} ns
   -i idle time (s)

--- a/wrappers/ruby/clkmgr_test.rb
+++ b/wrappers/ruby/clkmgr_test.rb
@@ -25,11 +25,11 @@ $chronyClockOffsetThreshold = 100000
 $subscribeAll = false
 $idleTime = 1
 $timeout = 10
-$event2Sub = (Clkmgr::EventGMOffset | Clkmgr::EventSyncedToGM |
-    Clkmgr::EventASCapable | Clkmgr::EventGMChanged)
-$composite_event = (Clkmgr::EventGMOffset | Clkmgr::EventSyncedToGM |
-    Clkmgr::EventASCapable)
-$chrony_event = Clkmgr::EventGMOffset
+$event2Sub = (Clkmgr::EventOffsetInRange | Clkmgr::EventSyncedWithGm |
+    Clkmgr::EventAsCapable | Clkmgr::EventGmChanged)
+$composite_event = (Clkmgr::EventOffsetInRange | Clkmgr::EventSyncedWithGm |
+    Clkmgr::EventAsCapable)
+$chrony_event = Clkmgr::EventOffsetInRange
 # Subscribe data
 $ptp4lSub = Clkmgr::PTPClockSubscription.new
 $chronySub = Clkmgr::SysClockSubscription.new
@@ -73,16 +73,16 @@ def printOut
     puts hd3
     if $composite_event != 0 then
         puts hd3b % ['ptp_isCompositeEventMet', ptpClock.isCompositeEventMet(), ptpClock.getCompositeEventCount()]
-        puts '| - %-26s | %-12s | %-11s |' % ['isOffsetInRange', '', ''] if $composite_event & Clkmgr::EventGMOffset
-        puts '| - %-26s | %-12s | %-11s |' % ['isSyncedWithGm', '', ''] if $composite_event & Clkmgr::EventSyncedToGM
-        puts '| - %-26s | %-12s | %-11s |' % ['isAsCapable', '', ''] if $composite_event & Clkmgr::EventASCapable
+        puts '| - %-26s | %-12s | %-11s |' % ['isOffsetInRange', '', ''] if $composite_event & Clkmgr::EventOffsetInRange
+        puts '| - %-26s | %-12s | %-11s |' % ['isSyncedWithGm', '', ''] if $composite_event & Clkmgr::EventSyncedWithGm
+        puts '| - %-26s | %-12s | %-11s |' % ['isAsCapable', '', ''] if $composite_event & Clkmgr::EventAsCapable
     end
     if $event2Sub != 0 then
         puts hd3
-        puts hd3b % ['ptp_isOffsetInRange', ptpClock.isOffsetInRange().to_s, ptpClock.getOffsetInRangeEventCount()] if $event2Sub & Clkmgr::EventGMOffset
-        puts hd3b % ['ptp_isSyncedWithGm', ptpClock.isSyncedWithGm().to_s, ptpClock.getSyncedWithGmEventCount()] if $event2Sub & Clkmgr::EventSyncedToGM
-        puts hd3b % ['ptp_isAsCapable', ptpClock.isAsCapable().to_s, ptpClock.getAsCapableEventCount()] if $event2Sub & Clkmgr::EventASCapable
-        puts hd3b % ['ptp_isGmChanged', ptpClock.isGmChanged().to_s, ptpClock.getGmChangedEventCount()] if $event2Sub & Clkmgr::EventGMChanged
+        puts hd3b % ['ptp_isOffsetInRange', ptpClock.isOffsetInRange().to_s, ptpClock.getOffsetInRangeEventCount()] if $event2Sub & Clkmgr::EventOffsetInRange
+        puts hd3b % ['ptp_isSyncedWithGm', ptpClock.isSyncedWithGm().to_s, ptpClock.getSyncedWithGmEventCount()] if $event2Sub & Clkmgr::EventSyncedWithGm
+        puts hd3b % ['ptp_isAsCapable', ptpClock.isAsCapable().to_s, ptpClock.getAsCapableEventCount()] if $event2Sub & Clkmgr::EventAsCapable
+        puts hd3b % ['ptp_isGmChanged', ptpClock.isGmChanged().to_s, ptpClock.getGmChangedEventCount()] if $event2Sub & Clkmgr::EventGmChanged
     end
     puts hd3
     puts '| %-28s |     %-19d ns |' % ['ptp_clockOffset', ptpClock.getClockOffset()]
@@ -131,15 +131,15 @@ Options
   -p enable user to subscribe to specific time base indices
   -s subscribe_event_mask
      Default: 0x#{$event2Sub.to_s(16)}
-     Bit 0: EventGMOffset
-     Bit 1: EventSyncedToGM
-     Bit 2: EventASCapable
-     Bit 3: EventGMChanged
+     Bit 0: EventOffsetInRange
+     Bit 1: EventSyncedWithGm
+     Bit 2: EventAsCapable
+     Bit 3: EventGmChanged
   -c composite_event_mask
      Default: 0x#{$composite_event.to_s(16)}
-     Bit 0: EventGMOffset
-     Bit 1: EventSyncedToGM
-     Bit 2: EventASCapable
+     Bit 0: EventOffsetInRange
+     Bit 1: EventSyncedWithGm
+     Bit 2: EventAsCapable
   -l gm offset threshold (ns)
      Default: #{$ptp4lClockOffsetThreshold} ns
   -i idle time (s)
@@ -148,7 +148,7 @@ Options
      Default: #{$chronyClockOffsetThreshold} ns
   -n chrony_event_mask
      Default: 0x#{$chrony_event.to_s(16)}
-     Bit 0: EventGMOffset
+     Bit 0: EventOffsetInRange
   -t $timeout in waiting notification event (s)
      Default: #{$timeout} s
 EOF

--- a/wrappers/ruby/clkmgr_test.rb
+++ b/wrappers/ruby/clkmgr_test.rb
@@ -103,9 +103,17 @@ def printOut
         puts hd3b % ['chrony_isOffsetInRange', sysClock.isOffsetInRange(), sysClock.getOffsetInRangeEventCount()]
         puts hd2l
         puts '| %-28s |     %-19d ns |' % ['chrony_clockOffset', sysClock.getClockOffset()]
-        identity_string = (0..3).map do |i|
-            ((sysClock.getGmIdentity() >> (8 * (3 - i))) & 0xFF).chr
-        end.join
+        identity_string = ''
+        (0..3).each do |i|
+            byteVal = (sysClock.getGmIdentity() >> (8 * (3 - i))) & 0xFF
+            if byteVal == 0 or byteVal == 9 then
+                identity_string += ' '
+            elsif /[[:print:]]/ === byteVal.chr
+                identity_string += byteVal.chr
+            else
+                identity_string += '.'
+            end
+        end
         puts '| %-28s |     %-19s    |' % ['chrony_gmIdentity', identity_string]
         puts '| %-28s |     %-19d us |' % ['chrony_syncInterval', sysClock.getSyncInterval()]
         puts '| %-28s |     %-19d ns |' % ['chrony_notificationTimestamp', sysClock.getNotificationTimestamp()]

--- a/wrappers/tcl/clkmgr_test.tcl
+++ b/wrappers/tcl/clkmgr_test.tcl
@@ -129,19 +129,24 @@ proc printOut {} {
         [ $ptpClock getNotificationTimestamp ]]
     puts $hd2l
     if {[clockSyncData haveSys]} {
-        if { $chrony_event != 0 } {
-            if { $chrony_event & $clkmgr::EventGMOffset } {
-                puts [format $hd3b "chrony_isOffsetInRange"\
-                    [ $sysClock isOffsetInRange ]\
-                    [ $sysClock getOffsetInRangeEventCount ]]
-            }
-        }
+        puts [format $hd3b "chrony_isOffsetInRange"\
+            [ $sysClock isOffsetInRange ]\
+            [ $sysClock getOffsetInRangeEventCount ]]
         puts $hd2l
         puts [format "| %-28s |     %-19ld ns |"\
             "chrony_clockOffset" [ $sysClock getClockOffset ]]
         for {set i 0} {$i < 4} {incr i} {
             set byte [expr {([$sysClock getGmIdentity] >> (8 * (3 - $i))) & 0xFF}]
-            append identity_string [format "%c" $byte]
+            if { $byte == 0 || $byte == 9 } {
+                append identity_string " "
+            } else {
+                set s [format "%c" $byte]
+                if { [ string is print $s ] } {
+                    append identity_string $s
+                } else {
+                    append identity_string "."
+                }
+            }
         }
         puts [format "| %-28s |     %-19s    |"\
             "chrony_gmIdentity" $identity_string ]

--- a/wrappers/tcl/clkmgr_test.tcl
+++ b/wrappers/tcl/clkmgr_test.tcl
@@ -75,37 +75,37 @@ proc printOut {} {
         puts [format $hd3b "ptp_isCompositeEventMet"\
             [ $ptpClock isCompositeEventMet ]\
             [ $ptpClock getCompositeEventCount ]]
-        if { $composite_event & $clkmgr::EventGMOffset } {
+        if { $composite_event & $clkmgr::EventOffsetInRange } {
             puts [format "| - %-26s | %-12s | %-11s |"\
                 "isOffsetInRange" "" ""]
         }
-        if { $composite_event & $clkmgr::EventSyncedToGM } {
+        if { $composite_event & $clkmgr::EventSyncedWithGm } {
             puts [format "| - %-26s | %-12s | %-11s |"\
                 "isSyncedWithGm" "" ""]
         }
-        if { $composite_event & $clkmgr::EventASCapable } {
+        if { $composite_event & $clkmgr::EventAsCapable } {
             puts [format "| - %-26s | %-12s | %-11s |"\
                 "isAsCapable" "" ""]
         }
     }
     if { $event2Sub != 0 } {
         puts $hd3
-        if { $event2Sub & $clkmgr::EventGMOffset } {
+        if { $event2Sub & $clkmgr::EventOffsetInRange } {
             puts [format $hd3b "ptp_isOffsetInRange"\
                 [ $ptpClock isOffsetInRange ]\
                 [ $ptpClock getOffsetInRangeEventCount ]]
         }
-        if { $event2Sub & $clkmgr::EventSyncedToGM } {
+        if { $event2Sub & $clkmgr::EventSyncedWithGm } {
             puts [format $hd3b "ptp_isSyncedWithGm"\
                 [ $ptpClock isSyncedWithGm ]\
                 [ $ptpClock getSyncedWithGmEventCount ]]
         }
-        if { $event2Sub & $clkmgr::EventASCapable } {
+        if { $event2Sub & $clkmgr::EventAsCapable } {
             puts [format $hd3b "ptp_isAsCapable"\
                 [ $ptpClock isAsCapable ]\
                 [ $ptpClock getAsCapableEventCount ]]
         }
-        if { $event2Sub & $clkmgr::EventGMChanged } {
+        if { $event2Sub & $clkmgr::EventGmChanged } {
             puts [format $hd3b "ptp_isGmChanged"\
                 [ $ptpClock isGmChanged ]\
                 [ $ptpClock getGmChangedEventCount ]]
@@ -163,11 +163,11 @@ proc main {} {
     global argv argv0 index subscribeAll event2Sub composite_event chrony_event\
         clockSyncData ptp4lSub chronySub idleTime timeout
     # index list of indexes to subscribe
-    set event2Sub [expr $clkmgr::EventGMOffset | $clkmgr::EventSyncedToGM |\
-        $clkmgr::EventASCapable | $clkmgr::EventGMChanged ]
-    set composite_event [expr $clkmgr::EventGMOffset |\
-        $clkmgr::EventSyncedToGM | $clkmgr::EventASCapable ]
-    set chrony_event $clkmgr::EventGMOffset
+    set event2Sub [expr $clkmgr::EventOffsetInRange | $clkmgr::EventSyncedWithGm |\
+        $clkmgr::EventAsCapable | $clkmgr::EventGmChanged ]
+    set composite_event [expr $clkmgr::EventOffsetInRange |\
+        $clkmgr::EventSyncedWithGm | $clkmgr::EventAsCapable ]
+    set chrony_event $clkmgr::EventOffsetInRange
     set options {
         {h}
         {a}
@@ -203,18 +203,18 @@ Options:
   -p enable user to subscribe to specific time base indices
   -s subscribe_event_mask
      Default: 0x[format %x $event2Sub ]
-     Bit 0: EventGMOffset
-     Bit 1: EventSyncedToGM
-     Bit 2: EventASCapable
-     Bit 3: EventGMChanged
+     Bit 0: EventOffsetInRange
+     Bit 1: EventSyncedWithGm
+     Bit 2: EventAsCapable
+     Bit 3: EventGmChanged
   -c composite_event_mask
      Default: 0x[format %x $composite_event ]
-     Bit 0: EventGMOffset
-     Bit 1: EventSyncedToGM
-     Bit 2: EventASCapable
+     Bit 0: EventOffsetInRange
+     Bit 1: EventSyncedWithGm
+     Bit 2: EventAsCapable
   -n chrony_event_mask
      Default: 0x[format %x $chrony_event ]
-     Bit 0: EventGMOffset
+     Bit 0: EventOffsetInRange
   -l gm offset threshold (ns)
      Default: 100000 ns
   -i idle time (s)


### PR DESCRIPTION
<h1>Suggested PR Title - Update Event Mask Enum Values and Improve Documentation and Test Scripts</h1>

<h1 style='color: red;'>${\color{red}DO \space NOT \space EDIT \space ANYTHING}$</h1>

### Smart DevOps AI Agent for GitHub: Release Version: v1.2-ww18-2025


>### Start of generated PR Summary by Smart DevOps Agent for GitHub

## Types of major changes in the pull request
code_enhancement, feature_enhancement


___

## Pull request change summary
- Updated event mask enum values across multiple files for clarity.
- Removed redundant inline comments and updated documentation comments from @brief to regular comments in several files.
- Made global variables static in test samples and improved handling of non-printable characters in output.
- Added libsystemd-dev and systemd-devel to Docker setup scripts for Debian and RPM.
- Updated test scripts in various languages to use the new event mask enum values.
- Added a conditional check in the GitHub workflow to ensure the job runs only if the previous workflow was successful.


___

## High level Pull Request Summary
<table><thead><tr><th>Filename&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Summary of changes&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Link to file&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody>
<tr>
  <td><strong>clkmgr/client/client_state.hpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Removed redundant inline member variable comments in <br>ClientState class.
 <br><br> Type of change: <br>Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-c564764ac89bc6fa4083a2ce0957ea48f491fa4d1320f15d8bddcc3f939402fd"> +2/-2</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/sample/clkmgr_test.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Made global variables static, updated event mask enum <br>values, and improved the print function to handle <br>non-printable characters.
 <br><br> Type of change: <br>Code_Improvement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-39d8863e2f42d4a016139a23a804368bc9d910f36a372ee321de5dd51f85697e"> +47/-44</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/client/connect_msg.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the function documentation style from @brief to <br>regular comments in connect_msg.cpp.
 <br><br> Type of <br>change: Code_Documentation</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-8e1975f36904f986d2575d14be1a4ac3fe454f2bf46652bb7724102c1f68188b"> +1/-1</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/client/subscribe_msg.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the function documentation style from @brief to <br>regular comments in subscribe_msg.cpp.
 <br><br> Type of <br>change: Code_Documentation</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-b39fd775e0a0a88be790e4f94c6cc48e160899d1726b308bfcefddab4dc6e843"> +1/-1</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/proxy/connect_msg.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the function documentation style from @brief to <br>regular comments in connect_msg.cpp.
 <br><br> Type of <br>change: Code_Documentation</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-0d8035501530b69f603d8989cb2d567a0d89543ba63aed32f052a3b76f35fb30"> +1/-1</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/proxy/connect_ptp4l.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the function documentation style from @brief to <br>regular comments in connect_ptp4l.cpp.
 <br><br> Type of <br>change: Code_Documentation</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-da95cc8b767ef4c8d14e02eb953540fcf521dff4d17fd0492d131b0eebd75471"> +3/-3</a></td>

</tr>                    

<tr>
  <td><strong>rpm/make_docker.sh</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added comments and formatted the script for better <br>readability.
 <br><br> Type of change: Code_Documentation</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-0637e08d8c38955b5d6c0033690a08dbd9013f9783c3bf3b3a93b9e15bb27697"> +2/-0</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/TEST_clkmgr.md</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the test documentation to reflect the new event mask <br>enum values.
 <br><br> Type of change: Code_Documentation</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-7840c1bf0f0c33faf4cd25d8ac090566386bc07e576091949f0869c47107e48f"> +7/-7</a></td>

</tr>                    

<tr>
  <td><strong>gentoo/Dockerfile</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added comments to describe the use of emerge flags in the <br>Dockerfile.
 <br><br> Type of change: Code_Documentation</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-78eeb03c7bb19e7dfb26753cb731649049839e73d3ab3f050c89f3651f683b0b"> +2/-0</a></td>

</tr>                    

<tr>
  <td><strong>gentoo/Dockerfile.1</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the URL for searching packages in the Gentoo <br>Dockerfile.
 <br><br> Type of change: Code_Documentation</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-f8031629a32e8e670fb1ea31aa213a97aa38742ca80a5773ad54614954f4499e"> +1/-1</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/client/timebase_state.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Renamed event mask enum values to improve clarity and <br>updated related conditional checks.
 <br><br> Type of <br>change: Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-9377401fe8c6585d9e3cb535ac48e73e24e1e6794d28afe70544100f882ba2a7"> +12/-12</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/common/types.m4</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Renamed event mask enum values in the core enum definition <br>to improve clarity.
 <br><br> Type of change: <br>Feature_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-5bdb52786941d27ed8aeaa79e7b1acb31c97e8183152bcf7c25f142f16c193e7"> +13/-11</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/utest/clockmanager.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated test cases to use the new event mask enum values.
 <br><br><br> Type of change: Update_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-28560a354cbf8de0be5dfdc51ed292271c23e50a62638518af9e65125a9bbd1d"> +4/-4</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/sample/clkmgr_c_test.c</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the C test sample to use the new event mask enum <br>values and made global variables static.
 <br><br> Type of <br>change: Update_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-f51b46df65bf7e722821f43e78e70047b5b6c576a73988348e400d49c96bfda5"> +43/-37</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/perl/clkmgr_test.pl</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the Perl wrapper test script to use the new event <br>mask enum values.
 <br><br> Type of change: Update_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-3a2c533656da6ce40a239fd81d17b21c4313f3b8bd13281aa916024bd5064f6f"> +30/-21</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/python/clkmgr_test.py</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the Python wrapper test script to use the new event <br>mask enum values.
 <br><br> Type of change: Update_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-c2fa5eb89c17a0fa21256311015f54296963450d754ba9c08a3b22454b643fe4"> +31/-23</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/go/clkmgr_gtest/clkmgr_gtest.go</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the Go wrapper test script to use the new event mask <br>enum values and added a function to delete subscriptions.
 <br><br><br> Type of change: Update_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-ddc1c2ebf4af0579295966e469d8cee5ae1527d4f7c1f0c0f514040d7a537cbe"> +50/-45</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/lua/clkmgr_test.lua</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the Lua wrapper test script to use the new event <br>mask enum values.
 <br><br> Type of change: Update_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-e4a3f2cafe21fb69eedd39ba99aec8301477c737e53d3db1e3eacf58de19e2c7"> +40/-32</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/tcl/clkmgr_test.tcl</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the Tcl wrapper test script to use the new event <br>mask enum values.
 <br><br> Type of change: Update_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-156d703e74e1cd5de2070ecbe427bfd40e8423221bf17e40358b730663bf5944"> +33/-28</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/php/clkmgr_test.php</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the PHP wrapper test script to use the new event <br>mask enum values.
 <br><br> Type of change: Update_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-d0e5724efe218dac081e598a234a92a8f1f5f025137ce247cc4719850d07460c"> +73/-64</a></td>

</tr>                    

<tr>
  <td><strong>wrappers/ruby/clkmgr_test.rb</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Updated the Ruby wrapper test script to use the new event <br>mask enum values.
 <br><br> Type of change: Update_Tests</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-e18543c5165d398f09255820f6f92664e5afed37232ea04a5ce80a432d05f612"> +31/-23</a></td>

</tr>                    

<tr>
  <td><strong>debian/make_docker.sh</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added libsystemd-dev to the list of packages to be installed <br>in the Docker setup script.
 <br><br> Type of change: <br>Configuration_Changes</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-13515ff449b9dcb19320ffc78c3c44563b7f9b0ac8fd6b398807a85d0f691ebd"> +1/-1</a></td>

</tr>                    

<tr>
  <td><strong>.github/workflows/build_gentoo2.yml</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added a conditional check to run the job only if the <br>previous workflow run was successful.
 <br><br> Type of <br>change: Configuration_Changes</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-08bc3292e5cba0b008cc0e036e903adb13069eabc987e54d1d95990b7c2f28f4"> +1/-0</a></td>

</tr>                    

<tr>
  <td><strong>archlinux/Dockerfile</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added systemd-libs to the list of packages to be installed <br>in the Dockerfile.
 <br><br> Type of change: <br>Configuration_Changes</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-67f17703e70a45a58f3a7be0cd848093febf0c6b1bb5d59a483776d56bb56456"> +2/-1</a></td>

</tr>                    

<tr>
  <td><strong>rpm/Dockerfile</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added systemd-devel to the list of packages to be installed <br>in the Dockerfile.
 <br><br> Type of change: <br>Configuration_Changes</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/248/files#diff-28680721b21a395f1041fc66be2bc83027e7cec3158f750f9e5b7482dc5a3efd"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

>### End of generated PR Summary by Smart DevOps Agent for GitHub