### PR TITLE
clkmgr: Fix unit test isolation issues and default event state.

### DIFF
--- a/clkmgr/pub/clkmgr/event.h
+++ b/clkmgr/pub/clkmgr/event.h
@@ -131,7 +131,7 @@ class ClockEventBase
     uint64_t notificationTimestamp = 0;
     uint32_t offsetInRangeCount = 0; /**< Count of offsets within defined range. */
     uint32_t gmChangedCount = 0; /**< Count of grandmaster clock changes. */
-    bool offsetInRange = false; /**< Indicates if the offset is within range. */
+    bool offsetInRange = true; /**< Indicates if the offset is within range. */
     bool gmChanged = false; /**< Indicates if the grandmaster clock has changed. */
     /**< @endcond */
 };

--- a/clkmgr/utest/client_state.cpp
+++ b/clkmgr/utest/client_state.cpp
@@ -95,8 +95,15 @@ TEST_F(ClientStateTest, init)
 // bool sendMessage(Message &msg)
 TEST_F(ClientStateTest, sendMessage)
 {
+    // Ensure ClientState is initialized before sending message
+    if(ClientState::get_clientID().empty()) {
+        bool initResult = ClientState::init();
+        ASSERT_TRUE(initResult);
+    }
     ClientConnectMessage *cmsg = new ClientConnectMessage();
+    ASSERT_NE(cmsg, nullptr);
     EXPECT_TRUE(ClientState::sendMessage(*cmsg));
+    delete cmsg;
 }
 
 // Tests getTransmitter function
@@ -119,6 +126,11 @@ TEST_F(ClientStateTest, getTransmitter)
 // const std::string &get_clientID()
 TEST_F(ClientStateTest, connectAndReply)
 {
+    // Ensure ClientState is initialized before testing connect functionality
+    if(ClientState::get_clientID().empty()) {
+        bool initResult = ClientState::init();
+        ASSERT_TRUE(initResult);
+    }
     timespec lastConnectTime = {};
     bool result = false;
     // Simulate client not able to connect to proxy within timeout

--- a/clkmgr/utest/clockmanager.cpp
+++ b/clkmgr/utest/clockmanager.cpp
@@ -307,6 +307,9 @@ TEST_F(ClockManagerTest, getTimeBaseCfgs)
 //    size_t timeBaseIndex, ClockSyncData &clockSyncData)
 TEST_F(ClockManagerTest, subscribe)
 {
+    // Ensure connection is established before testing subscribe functionality
+    utest_connected_with_proxy = true;
+    ClockManager::connect();
     ClockSyncSubscription sub;
     ClockSyncData clData;
     EXPECT_FALSE(ClockManager::subscribeByName(sub, "xyz", clData));
@@ -344,6 +347,19 @@ TEST_F(ClockManagerTest, subscribe)
 //     ClockSyncData &clockSyncData)
 TEST_F(ClockManagerTest, statusWait)
 {
+    // Ensure connection and subscription are established before testing
+    utest_connected_with_proxy = true;
+    ClockManager::connect();
+    // Subscribe to timebase 1 to ensure the timebase state is active
+    utest_subscribed_with_proxy = true;
+    ClockSyncSubscription sub;
+    ClockSyncData dummyData;
+    ClockManager::subscribe(sub, 1, dummyData);
+    // Ensure timebase state is properly set up with events
+    ptp_event ptpData = {};
+    chrony_event chronyData = {};
+    TimeBaseStates::getInstance().setTimeBaseStatePtp(1, ptpData);
+    TimeBaseStates::getInstance().setTimeBaseStateSys(1, chronyData);
     ClockSyncData clData;
     EXPECT_EQ(ClockManager::statusWaitByName(0, "xyz", clData), -1);
     EXPECT_EQ(ClockManager::statusWait(0, 1, clData), 1);

--- a/clkmgr/utest/event.cpp
+++ b/clkmgr/utest/event.cpp
@@ -45,7 +45,7 @@ TEST(ClockEventBaseTest, defaultValue)
 {
     ClockEventBaseTestable event;
     EXPECT_EQ(event.getClockOffset(), 0);
-    EXPECT_FALSE(event.isOffsetInRange());
+    EXPECT_TRUE(event.isOffsetInRange());
     EXPECT_EQ(event.getOffsetInRangeEventCount(), 0u);
     EXPECT_EQ(event.getSyncInterval(), 0);
     EXPECT_EQ(event.getGmIdentity(), 0u);
@@ -244,7 +244,7 @@ TEST(SysClockEventTest, defaultValue)
 {
     SysClockEventTestable event;
     EXPECT_EQ(event.getClockOffset(), 0);
-    EXPECT_FALSE(event.isOffsetInRange());
+    EXPECT_TRUE(event.isOffsetInRange());
     EXPECT_EQ(event.getOffsetInRangeEventCount(), 0u);
 }
 


### PR DESCRIPTION
<h1>Suggested PR Title - Enhance clkmgr Unit Tests and Update Default Event State Handling</h1>
Tested with:
-make utest_clkmgr
-make utest_clkmgr ClientStateTest
-make utest_clkmgr ClientStateTest.connectAndReply
-make utest_clkmgr ClientStateTest.sendMessage
-make utest_clkmgr ClockManagerTest
-make utest_clkmgr ClockManagerTest.subsribe
-make utest_clkmgr ClockManagerTest.statusWait

Output of sample apps with isOffsetInRange event is "1" when offset is 0 for both ptp and chrony:
<img width="507" height="762" alt="image" src="https://github.com/user-attachments/assets/3e39f480-ea9d-48cc-ae2d-6f286cd513fb" />

<h1 style='color: red;'>${\color{red}DO \space NOT \space EDIT \space ANYTHING}$</h1>

### Smart DevOps AI Agent for GitHub: Release Version: v1.2-ww18-2025


>### Start of generated PR Summary by Smart DevOps Agent for GitHub

## Types of major changes in the pull request
code_enhancement, update_tests


___

## Pull request change summary
- Added initialization checks in ClientStateTest to ensure ClientState is properly initialized before sending messages or testing connection functionalities.
- Implemented memory management in ClientStateTest by deleting objects after use to prevent memory leaks.
- Ensured that necessary conditions like connection and subscription are established in ClockManagerTest before proceeding with subscription and status wait functionalities.
- Set up timebase states with events in ClockManagerTest to ensure the environment is correctly prepared for the tests.
- Updated the default state of isOffsetInRange to true in both ClockEventBaseTest and SysClockEventTest to reflect expected operational conditions.
- Updated the ClockEventBase class to have offsetInRange as true by default, impacting how events are processed.


___

## High level Pull Request Summary
<table><thead><tr><th>Filename&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Summary of changes&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th><th>Link to file&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </th></tr></thead><tbody>
<tr>
  <td><strong>clkmgr/utest/client_state.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Added initialization checks and memory management <br>improvements in the ClientStateTest unit tests to ensure <br>proper setup before running tests. This includes <br>initializing ClientState if not already done and ensuring <br>objects are deleted after use to prevent memory leaks. <br><br><br> Type of change: Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/263/files#diff-ebf5f40e3550b2fa11b7e1d28644bc8a9d27fa5a61fb75cd8f68dbff3612eb83"> +10/-0</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/utest/clockmanager.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Enhanced the ClockManagerTest unit tests by ensuring <br>necessary conditions like connection and subscription are <br>met before proceeding with tests. This includes connecting <br>to a proxy and subscribing to a timebase, as well as setting <br>up timebase states with events to ensure the environment is <br>correctly prepared for the tests. <br><br> Type of change: <br>Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/263/files#diff-28560a354cbf8de0be5dfdc51ed292271c23e50a62638518af9e65125a9bbd1d"> +16/-0</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/utest/event.cpp</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Modified the default state of isOffsetInRange from false to <br>true in the ClockEventBaseTest and SysClockEventTest unit <br>tests. This change aligns the initial state with expected <br>conditions in operational scenarios. <br><br> Type of <br>change: Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/263/files#diff-f84296279978bb00abf836aaf90d5f02322d05b40c83267d0430fc4774bf14c5"> +2/-2</a></td>

</tr>                    

<tr>
  <td><strong>clkmgr/pub/clkmgr/event.h</strong></td>
  <td>
    <details>
      <summary><strong>Expand Summary</strong></summary>
      <ul>
<b>Changed the default value of the offsetInRange member in the <br>ClockEventBase class from false to true. This adjustment <br>ensures that the offset is considered within range by <br>default, which may affect how events are handled in the <br>system. <br><br> Type of change: Code_Enhancement</b>
</ul>
    </details>
  </td>
  <td><a href="https://github.com/intel-staging/libptpmgmt_iaclocklib/pull/263/files#diff-feb441c02acc85ffa6a570a44e1c771b7699fab74756c38b1e37afb682d0e579"> +1/-1</a></td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

>### End of generated PR Summary by Smart DevOps Agent for GitHub