### PR TITLE
clkmgr: Fix ptp_isSyncedWithGm to reflect properly

### DIFF
--- a/clkmgr/proxy/connect_ptp4l.cpp
+++ b/clkmgr/proxy/connect_ptp4l.cpp
@@ -163,6 +163,9 @@ callback_define(PORT_DATA_SET)
             portDataReset();
             break;
         case MASTER:
+            // Ignore unchanged gmIdentity
+            if(gmIdentity == tlv.portIdentity.clockIdentity)
+                return;
             // Set own clock identity as GM identity
             portDataReset();
             event.event.gmClockUUID = 0;


### PR DESCRIPTION
- `ptp_isSyncedWithGm` shows 0 when `clkmgr_proxy` starts after `ptp4l` is already synced.
- Adds a check to ensure the port data set is only reset when the gmIdentity actually changes, preventing unnecessary resets and ensuring correct sync status reporting.

Results:
C++:
<img width="746" height="1032" alt="image" src="https://github.com/user-attachments/assets/dc6e5b47-7eea-4e44-889c-245933894048" />

C:
<img width="674" height="1212" alt="image" src="https://github.com/user-attachments/assets/a556ab68-efa7-4679-a8a8-3b1fe254dc5e" />
