### PR TITLE
clkmgr: Fix clkmgr_proxy_cfg man file name mismatch

### DIFF
--- a/clkmgr/clkmgr_proxy_cfg.md
+++ b/clkmgr/clkmgr_proxy_cfg.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: GFDL-1.3-no-invariants-or-later
      SPDX-FileCopyrightText: Copyright © 2025 Intel Corporation. -->
 ---
-title: PROXY_CFG
+title: CLKMGR_PROXY_CFG
 section: 5
 header: JSON File Formats Manual
 date: July 2025
@@ -9,7 +9,7 @@ date: July 2025
 
 # NAME
 
-proxy_cfg - **Clock Manager** proxy service JSON configuration file  
+clkmgr_proxy_cfg - **Clock Manager** proxy service JSON configuration file  
 
 # DESCRIPTION
 


### PR DESCRIPTION
Correct the man page title and NAME section from "PROXY_CFG" and "proxy_cfg" to "CLKMGR_PROXY_CFG" and "clkmgr_proxy_cfg" for consistency with the actual file name.

<img width="2652" height="1519" alt="image" src="https://github.com/user-attachments/assets/459cdc56-5a80-4dce-800e-b1e5327ab5e7" />
