### PR TITLE
clkmgr: Clean up residual message queues on client

### DIFF
--- a/clkmgr/common/msgq_tport.cpp
+++ b/clkmgr/common/msgq_tport.cpp
@@ -69,7 +69,11 @@ bool Queue::RxOpen(const string &n, size_t maxMsg, bool allRx)
 bool Queue::TxOpen(const string &n, bool block)
 {
     mq = mq_open(n.c_str(), O_WRONLY | (block ? 0 : O_NONBLOCK));
-    return exist();
+    if(exist()) {
+        clientId = n;
+        return true;
+    }
+    return false;
 }
 
 bool Queue::send(const void *ptr, size_t size) const

--- a/clkmgr/common/msgq_tport.hpp
+++ b/clkmgr/common/msgq_tport.hpp
@@ -134,6 +134,9 @@ class Transmitter
     bool sendBuffer(Buffer &buf);
     bool open(const std::string &name, bool block = true);
     std::string getQueueName() const { return m_transmitterQueue.str(); }
+    const std::string &getClientId() const {
+        return m_transmitterQueue.getClientId();
+    }
     static Transmitter *getTransmitterInstance(sessionId_t sessionId);
 };
 

--- a/clkmgr/proxy/client.cpp
+++ b/clkmgr/proxy/client.cpp
@@ -168,8 +168,12 @@ void Client::RemoveClient(sessionId_t sessionId)
     Client *client = getClient(sessionId);
     if(client != nullptr) {
         Transmitter *tx = client->getTransmitter();
-        if(tx != nullptr)
+        if(tx != nullptr) {
             tx->finalize();
+            std::string mqClientName = tx->getClientId();
+            if(!mqClientName.empty() && !mq_unlink(mqClientName.c_str()))
+                PrintInfo("Cleaning residue message queue: " + mqClientName);
+        }
     }
     sessionMap.erase(sessionId);
     mapLock.unlock(); // Explicitly unlock the mutex


### PR DESCRIPTION
If a client terminates unexpectedly, its POSIX message queue may be left behind. This update ensures that any such residual message queues are properly unlinked, preventing resource leaks and avoiding issues with stale queues persisting after client termination. The transmitter now records the client queue name, and the client removal logic attempts to unlink the queue if it exists.

<img width="1602" height="138" alt="image" src="https://github.com/user-attachments/assets/0d3c5494-1af1-4f19-930a-38811be0bf8b" />
