### PR TITLE
clkmgr: Update Github Actions for SDLE compliance.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,18 +23,36 @@ permissions:
 
 env:
   USER: builder
+  FORKY_SHA: e7be87dc866c0682b4cb177fbdd54eba853e50a5ebee8d96a6439708434100ff
+  TRIXIE_SHA: caa451c42050445ffbff1992442ec9526a481b392e758d0c2e071a4a55935bc8
+  BOOKWORM_SHA: 4dbbe60338cb77c8cd7142e5054426124f6d824330a6f8f4e7413aef7c61d0a8
+  RPMBUILD_SHA: 64343fc4d5eb7a4f66339959630c94e543c9d45f5fc6ee201db2fd4bd566265f
+  PACMANBUILD_SHA: 4a8c2e3c5885792a819a307d8be64e9cd44ac0b5bf220020c3130615c4278486
+  PORTAGE_SHA: fa18e53f1587d47751e2f611a31a5b5af3731edae6c5e5e7b2d5b6a825b3ee85
 
 jobs:
   ci:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        names: [deb.forky, deb.trixie, deb.bookworm, rpmbuild, pacmanbuild, portage]
+        include:
+          - name: deb.forky
+            sha: ${{ env.FORKY_SHA }}
+          - name: deb.trixie
+            sha: ${{ env.TRIXIE_SHA }}
+          - name: deb.bookworm
+            sha: ${{ env.BOOKWORM_SHA }}
+          - name: rpmbuild
+            sha: ${{ env.RPMBUILD_SHA }}
+          - name: pacmanbuild
+            sha: ${{ env.PACMANBUILD_SHA }}
+          - name: portage
+            sha: ${{ env.PORTAGE_SHA }}
       fail-fast: false
     container:
-      image: ghcr.io/erezgeva/${{ matrix.names }}:latest
+      image: ghcr.io/erezgeva/${{ matrix.name }}@sha256:${{ matrix.sha }}
     env:
-      GITHUB_CONTAINER: ${{ matrix.names }}
+      GITHUB_CONTAINER: ${{ matrix.name }}
 
     steps:
 
@@ -60,10 +78,16 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        names: [deb.forky, deb.trixie, deb.bookworm]
+        include:
+          - name: deb.forky
+            sha: ${{ env.FORKY_SHA }}
+          - name: deb.trixie
+            sha: ${{ env.TRIXIE_SHA }}
+          - name: deb.bookworm
+            sha: ${{ env.BOOKWORM_SHA }}
       fail-fast: false
     container:
-      image: ghcr.io/erezgeva/${{ matrix.names }}:latest
+      image: ghcr.io/erezgeva/${{ matrix.name }}@sha256:${{ matrix.sha }}
 
     steps:
 
@@ -81,12 +105,24 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        names: [deb.forky, deb.trixie, deb.bookworm, rpmbuild, pacmanbuild, portage]
+        include:
+          - name: deb.forky
+            sha: ${{ env.FORKY_SHA }}
+          - name: deb.trixie
+            sha: ${{ env.TRIXIE_SHA }}
+          - name: deb.bookworm
+            sha: ${{ env.BOOKWORM_SHA }}
+          - name: rpmbuild
+            sha: ${{ env.RPMBUILD_SHA }}
+          - name: pacmanbuild
+            sha: ${{ env.PACMANBUILD_SHA }}
+          - name: portage
+            sha: ${{ env.PORTAGE_SHA }}
       fail-fast: false
     container:
-      image: ghcr.io/erezgeva/${{ matrix.names }}:latest
+      image: ghcr.io/erezgeva/${{ matrix.name }}@sha256:${{ matrix.sha }}
     env:
-      GITHUB_CONTAINER: ${{ matrix.names }}
+      GITHUB_CONTAINER: ${{ matrix.name }}
 
     steps:
 
@@ -140,7 +176,7 @@ jobs:
   abi:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/erezgeva/deb.forky:latest
+      image: ghcr.io/erezgeva/deb.forky@sha256:${{ env.FORKY_SHA }}
 
     steps:
 

--- a/.github/workflows/clock_manager_e2e.yml
+++ b/.github/workflows/clock_manager_e2e.yml
@@ -17,11 +17,14 @@ on: workflow_dispatch
 permissions:
   contents: read
 
+env:
+  FORKY_SHA: e7be87dc866c0682b4cb177fbdd54eba853e50a5ebee8d96a6439708434100ff
+
 jobs:
   clkmgr_e2e:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/erezgeva/deb.forky:latest
+      image: ghcr.io/erezgeva/deb.forky@sha256:${{ env.FORKY_SHA }}
     env:
       GITHUB_CONTAINER: deb.forky
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -31,7 +31,7 @@ jobs:
       run: tools/ci_coverity.sh
 
     - name: coverity scan
-      uses: vapier/coverity-scan-action@v1
+      uses: vapier/coverity-scan-action@2068473c7bdf8c2fb984a6a40ae76ee7facd7a85 # v1
       with:
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/.github/workflows/coverity_clang.yml
+++ b/.github/workflows/coverity_clang.yml
@@ -31,7 +31,7 @@ jobs:
       run: tools/ci_coverity.sh clang
 
     - name: coverity scan
-      uses: vapier/coverity-scan-action@v1
+      uses: vapier/coverity-scan-action@2068473c7bdf8c2fb984a6a40ae76ee7facd7a85 # v1
       with:
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/.github/workflows/man.yml
+++ b/.github/workflows/man.yml
@@ -20,12 +20,13 @@ permissions:
 
 env:
   USER: builder
+  FORKY_SHA: e7be87dc866c0682b4cb177fbdd54eba853e50a5ebee8d96a6439708434100ff
 
 jobs:
   full:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/erezgeva/deb.forky:latest
+      image: ghcr.io/erezgeva/deb.forky@sha256:${{ env.FORKY_SHA }}
 
     steps:
 
@@ -74,7 +75,7 @@ jobs:
         names: [utest_address, utest_valgrid]
       fail-fast: false
     container:
-      image: ghcr.io/erezgeva/deb.forky:latest
+      image: ghcr.io/erezgeva/deb.forky@sha256:${{ env.FORKY_SHA }}
     env:
       GITHUB_TOOL: ${{ matrix.names }}
 


### PR DESCRIPTION
Changes:
- Pin docker images to the latest digest.
- Pin `vapier/coverity-scan-action` to a specific commit hash.