### PR TITLE
clkmgr: Update Github Actions for SDLE compliance.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,24 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        names: [deb.forky, deb.trixie, deb.bookworm, rpmbuild, pacmanbuild, portage]
+        include:
+          - name: deb.forky
+            sha: fe6dcd99d5f97d24a13cdb59040ce131647381bf604854d68c2f7f259f84e03c
+          - name: deb.trixie
+            sha: 49391f56cd7fdbadfd178504718040e546f87a3382079c0962d802b46b62291e
+          - name: deb.bookworm
+            sha: 549cf623d65e90f9bd3165c349ba33a2da80c60dd89fa717e7f33f219b1b948b
+          - name: rpmbuild
+            sha: 5a0c44a7752755385102da021551fa703932ff2208312aa99101e8506376f49d
+          - name: pacmanbuild
+            sha: 8c90cb4f3ad1c261d6cd852cfb6e281b96d7cd64632a3fcf7490ebd70ac90cca
+          - name: portage
+            sha: 59a4e0d118f790366876f1fb8cacf196564339a553f2a0b1208c67248d8d4ed0
       fail-fast: false
     container:
-      image: ghcr.io/erezgeva/${{ matrix.names }}:latest
+      image: ghcr.io/erezgeva/${{ matrix.name }}@sha256:${{ matrix.sha }}
     env:
-      GITHUB_CONTAINER: ${{ matrix.names }}
+      GITHUB_CONTAINER: ${{ matrix.name }}
 
     steps:
 
@@ -60,10 +72,16 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        names: [deb.forky, deb.trixie, deb.bookworm]
+        include:
+          - name: deb.forky
+            sha: fe6dcd99d5f97d24a13cdb59040ce131647381bf604854d68c2f7f259f84e03c
+          - name: deb.trixie
+            sha: 49391f56cd7fdbadfd178504718040e546f87a3382079c0962d802b46b62291e
+          - name: deb.bookworm
+            sha: 549cf623d65e90f9bd3165c349ba33a2da80c60dd89fa717e7f33f219b1b948b
       fail-fast: false
     container:
-      image: ghcr.io/erezgeva/${{ matrix.names }}:latest
+      image: ghcr.io/erezgeva/${{ matrix.name }}@sha256:${{ matrix.sha }}
 
     steps:
 
@@ -81,12 +99,24 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        names: [deb.forky, deb.trixie, deb.bookworm, rpmbuild, pacmanbuild, portage]
+        include:
+          - name: deb.forky
+            sha: fe6dcd99d5f97d24a13cdb59040ce131647381bf604854d68c2f7f259f84e03c
+          - name: deb.trixie
+            sha: 49391f56cd7fdbadfd178504718040e546f87a3382079c0962d802b46b62291e
+          - name: deb.bookworm
+            sha: 549cf623d65e90f9bd3165c349ba33a2da80c60dd89fa717e7f33f219b1b948b
+          - name: rpmbuild
+            sha: 5a0c44a7752755385102da021551fa703932ff2208312aa99101e8506376f49d
+          - name: pacmanbuild
+            sha: 8c90cb4f3ad1c261d6cd852cfb6e281b96d7cd64632a3fcf7490ebd70ac90cca
+          - name: portage
+            sha: 59a4e0d118f790366876f1fb8cacf196564339a553f2a0b1208c67248d8d4ed0
       fail-fast: false
     container:
-      image: ghcr.io/erezgeva/${{ matrix.names }}:latest
+      image: ghcr.io/erezgeva/${{ matrix.name }}@sha256:${{ matrix.sha }}
     env:
-      GITHUB_CONTAINER: ${{ matrix.names }}
+      GITHUB_CONTAINER: ${{ matrix.name }}
 
     steps:
 
@@ -131,7 +161,7 @@ jobs:
       run: timeout 50 libptpmgmt/clkmgr/tool/sim.sh 0
 
     - name: test with linuxptp without the development package
-      if: ${{ matrix.names != 'portage' }}
+      if: ${{ matrix.name != 'portage' }}
       run: libptpmgmt/tools/ci_pkgs_no_dev.sh
 
     - name: test clock manager with clknetsim without the development package
@@ -140,7 +170,7 @@ jobs:
   abi:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/erezgeva/deb.forky:latest
+      image: ghcr.io/erezgeva/deb.forky@sha256:fe6dcd99d5f97d24a13cdb59040ce131647381bf604854d68c2f7f259f84e03c
 
     steps:
 

--- a/.github/workflows/clock_manager_e2e.yml
+++ b/.github/workflows/clock_manager_e2e.yml
@@ -21,7 +21,7 @@ jobs:
   clkmgr_e2e:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/erezgeva/deb.forky:latest
+      image: ghcr.io/erezgeva/deb.forky@sha256:fe6dcd99d5f97d24a13cdb59040ce131647381bf604854d68c2f7f259f84e03c
     env:
       GITHUB_CONTAINER: deb.forky
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -31,7 +31,7 @@ jobs:
       run: tools/ci_coverity.sh
 
     - name: coverity scan
-      uses: vapier/coverity-scan-action@v1
+      uses: vapier/coverity-scan-action@2068473c7bdf8c2fb984a6a40ae76ee7facd7a85 # v1
       with:
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/.github/workflows/coverity_clang.yml
+++ b/.github/workflows/coverity_clang.yml
@@ -31,7 +31,7 @@ jobs:
       run: tools/ci_coverity.sh clang
 
     - name: coverity scan
-      uses: vapier/coverity-scan-action@v1
+      uses: vapier/coverity-scan-action@2068473c7bdf8c2fb984a6a40ae76ee7facd7a85 # v1
       with:
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/.github/workflows/man.yml
+++ b/.github/workflows/man.yml
@@ -25,7 +25,7 @@ jobs:
   full:
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/erezgeva/deb.forky:latest
+      image: ghcr.io/erezgeva/deb.forky@sha256:fe6dcd99d5f97d24a13cdb59040ce131647381bf604854d68c2f7f259f84e03c
 
     steps:
 
@@ -74,7 +74,7 @@ jobs:
         names: [utest_address, utest_valgrid]
       fail-fast: false
     container:
-      image: ghcr.io/erezgeva/deb.forky:latest
+      image: ghcr.io/erezgeva/deb.forky@sha256:fe6dcd99d5f97d24a13cdb59040ce131647381bf604854d68c2f7f259f84e03c
     env:
       GITHUB_TOOL: ${{ matrix.names }}
 


### PR DESCRIPTION
Changes:
- Pin docker images to the latest digest.
- Pin `vapier/coverity-scan-action` to a specific commit hash.

<img width="1302" height="862" alt="image" src="https://github.com/user-attachments/assets/ab14527f-eb9f-4cf5-8318-c80490fb9a90" />
